### PR TITLE
[이아람] w2_리뷰요청_마이크로서비스 api gateway 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.vscode

--- a/server/api-gateway/auth/passport.js
+++ b/server/api-gateway/auth/passport.js
@@ -1,0 +1,42 @@
+const passport = require("koa-passport");
+const LocalStrategy = require("passport-local").Strategy;
+const KakaoStrategy = require("passport-kakao").Strategy;
+
+const Partner = require("../models/partner");
+
+/**
+ * email / password를 사용한 로그인 전략
+ */
+passport.use(
+  new LocalStrategy(
+    {
+      usernameField: "email",
+      passwordField: "password"
+    },
+    (email, password, done) => {
+      Partner.findOne({ email: email, password: password }, (err, partner) => {
+        if (err) return done(err);
+        if (!partner) return done(null, false, { message: "로그인 실패" });
+        return done(null, partner);
+      });
+    }
+  )
+);
+
+/**
+ * 카카오 OAuth를 사용한 로그인 전략
+ */
+passport.use(
+  new KakaoStrategy(
+    {
+      clientID: clientID,
+      clientSecret: clientSecret, // clientSecret을 사용하지 않는다면 넘기지 말거나 빈 스트링을 넘길 것
+      callbackURL: callbackURL
+    },
+    (accessToken, refreshToken, profile, done) => {
+      // 사용자의 정보는 profile에 들어있다.
+    }
+  )
+);
+
+module.exports = passport;

--- a/server/api-gateway/auth/token-generator.js
+++ b/server/api-gateway/auth/token-generator.js
@@ -1,0 +1,16 @@
+const jwt = require("jsonwebtoken");
+
+/**
+ * JWT 토큰을 생성하는 함수
+ * @param {Object} data 토큰에 저장할 데이터 객체
+ * @returns jsonwebtoken
+ */
+const generateToken = data => {
+  const token = jwt.sign(data, process.env.JWT_SECRET, {
+    expiresIn: "7d"
+  });
+
+  return token;
+};
+
+module.exports = generateToken;

--- a/server/api-gateway/routes/auth.js
+++ b/server/api-gateway/routes/auth.js
@@ -1,0 +1,9 @@
+const Router = require("koa-router");
+const authRouter = new Router();
+const partnersRouter = require("./auth.partners");
+const usersRouter = require("./auth.users");
+
+authRouter.use("/partners", partnersRouter.routes());
+authRouter.use("/users", usersRouter.routes());
+
+module.exports = authRouter;

--- a/server/api-gateway/routes/auth.partners.js
+++ b/server/api-gateway/routes/auth.partners.js
@@ -1,0 +1,16 @@
+const Router = require("koa-router");
+const partnersRouter = new Router();
+const passport = require("../auth/passport");
+
+partnersRouter.post("/login", async (ctx, next) => {
+  return passport.authenticate("local", (err, user, info, status) => {
+    if (err) ctx.body = { msg: "시스템 에러" };
+    if (!user) ctx.body = { msg: info.message };
+
+    // jwt 토큰 생성
+    // 파트너 페이지로 redirection
+    ctx.body = { msg: "로그인 성공", user: user };
+  })(ctx);
+});
+
+module.exports = partnersRouter;

--- a/server/api-gateway/routes/auth.users.js
+++ b/server/api-gateway/routes/auth.users.js
@@ -1,0 +1,16 @@
+const Router = require("koa-router");
+const usersRouter = new Router();
+const passport = require("../auth/passport");
+
+usersRouter.post("/login", async (ctx, next) => {
+  return passport.authenticate("kakao", (err, user, info, status) => {
+    if (err) ctx.body = { msg: "시스템 에러" };
+    if (!user) ctx.body = { msg: info.message };
+
+    // jwt 토큰 생성
+    // 쿠키 설정 후 성공 메세지 전송
+    ctx.body = { msg: "로그인 성공", user: user };
+  })(ctx);
+});
+
+module.exports = usersRouter;


### PR DESCRIPTION
> 커밋 로그를 다시 정리하여 올립니다. @helloheesu
> 아직 깃 사용이나 리뷰 신청이 미숙하여 번거롭게 만든 점 죄송합니다. ㅠㅠ

**개발 상황**
- 마이크로서비스의 api gateway를 koa로 작성
- passport-local로 파트너(사용자) 로그인 인증 가능
- 추후 클라이언트에서 오는 graphql 쿼리를 처리하기 위해 apollo-serrver-koa 설치

![Untitled Diagram (1)](https://user-images.githubusercontent.com/39212304/68918097-2a16d780-07b0-11ea-8f23-59bf76fe29b8.png)


**질문**
- 저희 프로젝트에 이해관계자로 사용자, 파트너가 존재합니다. 사용자는 OAuth를 사용하여 서비스를 사용하고, 파트너는 자신의 스터디룸을 제공하며 통계를 확인할 수 있습니다. 둘 다 JWT 인증을 사용한다고 했을 떄, 어떤 정보를 토큰에 추가시키면 좋을까요?
  - 저희는 사용자 이름,  정도를 생각해보았습니다.
- 사용자와 파트너의 계정이 완전히 다르고, 한 개인이 사용자와 파트너 계정에 모두 가입을 할 수 있다고 할 때  파트너와 일반 사용자의 토큰 시크릿 키를 동일한 키로 사용해도 되는지 궁금합니다. (파트너와 일반 사용자는 JWT에 저장되는 데이터 필드가 다릅니다.)