### PR TITLE
테스트코드 추가 및 redis에 저장할 객체의 키 변경

### DIFF
--- a/server/lib/redis/index.js
+++ b/server/lib/redis/index.js
@@ -11,28 +11,28 @@ function returnRedisPromise(command, ...params) {
   })
 }
 
-exports.setAppbypName = async (appName, { host, port }) => {
+exports.setAppbyKey = async (key, { name, host, port }) => {
 
-  const isAlreadyExist = await returnRedisPromise("exists", appName);
+  const isAlreadyExist = await returnRedisPromise("exists", key);
 
-  if (isAlreadyExist === 0) return returnRedisPromise("hset", appName, "host", host, "port", port);
+  if (isAlreadyExist === 0) return returnRedisPromise("hset", key, "name", name, "host", host, "port", port);
 
   return new Promise(res => {
     res(0);
   })
 };
 
-exports.deletebypName = async (appName, { host, port }) => {
+exports.deletebyKey = async (key) => {
 
-  return returnRedisPromise("hset", appName, "host", host, "port", port);
+  return returnRedisPromise("del", key);
 };
 
-exports.updatdAppbypName = (appName, { host, port }) => {
-  return returnRedisPromise("hset", appName, "host", host, "port", port);
+exports.updatdAppbyKey = (key, { name, host, port }) => {
+  return returnRedisPromise("hset", key, "name", name, "host", host, "port", port);
 };
 
-exports.getAppbypName = appName => {
-  return returnRedisPromise("hgetall", appName);
+exports.getAppbyKey = (key) => {
+  return returnRedisPromise("hgetall", key);
 };
 
 exports.getAllApps = async () => {
@@ -48,3 +48,4 @@ exports.getAllApps = async () => {
 
   return apps;
 };
+

--- a/server/lib/redis/test/redis.test.js
+++ b/server/lib/redis/test/redis.test.js
@@ -1,0 +1,69 @@
+const { makePacket, makeKey } = require("../../tcp/util");
+const TcpServer = require("../../tcp/tcpServer");
+const TcpClient = require("../../tcp/tcpClient");
+const { setAppbyKey, deletebyKey, updateAppbyKey, getAppbyKey, getAllApps } = require("../index")
+
+
+
+/**
+ * setAppbyKey deleteAppbyKey getAppbyKey test
+ */
+test("setAppbyKey deleteAppbyKey getAppbyKey test", async () => {
+  const socket = {
+    remoteAddress: '127.0.0.1',
+    remotePort: 9000
+  }
+  const info = {
+    name: 'test',
+    host: '127.0.0.1',
+    port: '9000'
+  }
+  const key = await makeKey(socket)
+
+  await deletebyKey(key);
+  await setAppbyKey(key, info);
+
+  const expectApp = await getAppbyKey(key)
+
+  await deletebyKey(key);
+  expect(info).toEqual(expectApp);
+})
+
+
+/**
+ * getAllApp test
+ */
+test("getAllApp test", async () => {
+  const socket1 = {
+    remoteAddress: '127.0.0.1',
+    remotePort: 9000
+  }
+  const info1 = {
+    name: 'test1',
+    host: '127.0.0.1',
+    port: '9000'
+  }
+
+  const socket2 = {
+    remoteAddress: '127.0.0.1',
+    remotePort: 9001
+  }
+  const info2 = {
+    name: 'test2',
+    host: '127.0.0.1',
+    port: '9001'
+  }
+
+  const key1 = await makeKey(socket1)
+  const key2 = await makeKey(socket2)
+
+  await deletebyKey(key1);
+  await deletebyKey(key2);
+
+  await setAppbyKey(key1, info1);
+  await setAppbyKey(key2, info2);
+
+  const expectApps = await getAllApps()
+
+  expect([info1, info2]).toEqual(expect.arrayContaining(expectApps));
+})

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,8 @@
     "koa-router": "^7.4.0",
     "mongoose": "^5.7.10",
     "passport": "^0.4.0",
-    "passport-local": "^1.0.0"
+    "passport-local": "^1.0.0",
+    "redis": "^2.8.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",
@@ -27,7 +28,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
1. 레디스에 applist를 저장할 때 key를 appname에서 client 소켓의 정보로 만든 key로 변경
2. test 추가
3. redis package 추가