### PR TITLE
메인 페이지 프론트 상태 관리 및 라우팅 적용

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,6 @@
 import React, { useReducer, createContext } from "react";
 import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
 import { createGlobalStyle } from "styled-components";
-import PartnersRouter from "./pages/partners/Router";
 import Header from "./components/Header";
 import MainPage from "./pages/users/Main";
 import { initalState, mainReducer } from "./reducer/Main";
@@ -25,7 +24,6 @@ function App() {
           <Header />
           <Switch>
             <Route path="/" exact component={MainPage} />
-            <Route path="/partners" component={PartnersRouter} />
             <Route
               render={({ location }) => (
                 <div>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,7 +3,7 @@ import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
 import { createGlobalStyle } from "styled-components";
 import Header from "./components/Header";
 import MainPage from "./pages/users/Main";
-import { initalState, mainReducer } from "./reducer/Main";
+import { initalState, appReducer } from "./reducer/App";
 
 const GlobalStyle = createGlobalStyle`
   @import url(http://fonts.googleapis.com/earlyaccess/nanumgothic.css);
@@ -14,7 +14,7 @@ const GlobalStyle = createGlobalStyle`
 export const AppContext = createContext();
 
 function App() {
-  const [appState, appDispatch] = useReducer(mainReducer, initalState);
+  const [appState, appDispatch] = useReducer(appReducer, initalState);
 
   return (
     <div className="App">

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,7 @@ import MainPage from "./pages/users/Main";
 import { initalState, appReducer } from "./reducer/App";
 
 const GlobalStyle = createGlobalStyle`
+  @import "bulmaCarousel.sass";
   @import url(http://fonts.googleapis.com/earlyaccess/nanumgothic.css);
   @import url('https://fonts.googleapis.com/css?family=Black+Han+Sans&display=swap');
   font-family: "Nanum Gothic", sans-serif;

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useReducer, createContext } from "react";
 import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
 import { createGlobalStyle } from "styled-components";
 import PartnersRouter from "./pages/partners/Router";
 import Header from "./components/Header";
 import MainPage from "./pages/users/Main";
+import { initalState, mainReducer } from "./reducer/Main";
 
 const GlobalStyle = createGlobalStyle`
   @import url(http://fonts.googleapis.com/earlyaccess/nanumgothic.css);
@@ -11,24 +12,30 @@ const GlobalStyle = createGlobalStyle`
   font-family: "Nanum Gothic", sans-serif;
 `;
 
+export const AppContext = createContext();
+
 function App() {
+  const [appState, appDispatch] = useReducer(mainReducer, initalState);
+
   return (
     <div className="App">
       <GlobalStyle />
       <Router>
-        <Header />
-        <Switch>
-          <Route path="/" exact component={MainPage} />
-          <Route path="/partners" component={PartnersRouter} />
-          <Route
-            render={({ location }) => (
-              <div>
-                <h1>존재하지 않는 페이지입니다.</h1>
-                <p>{location.pathname}</p>
-              </div>
-            )}
-          />
-        </Switch>
+        <AppContext.Provider value={{ appState, appDispatch }}>
+          <Header />
+          <Switch>
+            <Route path="/" exact component={MainPage} />
+            <Route path="/partners" component={PartnersRouter} />
+            <Route
+              render={({ location }) => (
+                <div>
+                  <h1>존재하지 않는 페이지입니다.</h1>
+                  <p>{location.pathname}</p>
+                </div>
+              )}
+            />
+          </Switch>
+        </AppContext.Provider>
       </Router>
     </div>
   );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,9 @@
 import React from "react";
-import { Route, Switch } from "react-router-dom";
+import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
 import { createGlobalStyle } from "styled-components";
 import PartnersRouter from "./pages/partners/Router";
+import Header from "./components/Header";
+import MainPage from "./pages/users/Main";
 
 const GlobalStyle = createGlobalStyle`
   @import url(http://fonts.googleapis.com/earlyaccess/nanumgothic.css);
@@ -13,17 +15,21 @@ function App() {
   return (
     <div className="App">
       <GlobalStyle />
-      <Switch>
-        <Route path="/partners" component={PartnersRouter} />
-        <Route
-          render={({ location }) => (
-            <div>
-              <h1>존재하지 않는 페이지입니다.</h1>
-              <p>{location.pathname}</p>
-            </div>
-          )}
-        />
-      </Switch>
+      <Router>
+        <Header />
+        <Switch>
+          <Route path="/" exact component={MainPage} />
+          <Route path="/partners" component={PartnersRouter} />
+          <Route
+            render={({ location }) => (
+              <div>
+                <h1>존재하지 않는 페이지입니다.</h1>
+                <p>{location.pathname}</p>
+              </div>
+            )}
+          />
+        </Switch>
+      </Router>
     </div>
   );
 }

--- a/client/src/__test__/mainPage.dummy.js
+++ b/client/src/__test__/mainPage.dummy.js
@@ -20,12 +20,10 @@ const category = {
 };
 
 const miniCard = {
-  isLeader: true,
+  leader: "dlatns0201@gmail.com",
   img: "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
   title: "영화보면서 영어공부 같이해요~",
-  currentStudyCount: 3,
-  totalStudyCount: 23,
-  link: ""
+  isRecruiting: true
 };
 
 const myStudyData = [miniCard, miniCard, miniCard, miniCard];

--- a/client/src/__test__/mainPage.dummy.js
+++ b/client/src/__test__/mainPage.dummy.js
@@ -19,14 +19,33 @@ const category = {
   ]
 };
 
-const miniCard = {
+const miniCard1 = {
   leader: "dlatns0201@gmail.com",
   img: "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
   title: "영화보면서 영어공부 같이해요~",
   isRecruiting: true
 };
+const miniCard2 = {
+  leader: "dlatns0202@gmail.com",
+  img: "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
+  title: "HTML은 프로그래밍 언어가 아니다~",
+  isRecruiting: false
+};
 
-const myStudyData = [miniCard, miniCard, miniCard, miniCard];
+const miniCard3 = {
+  leader: "dlatns0202@gmail.com",
+  img: "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
+  title: "김세진도 좋아하는 Java 프로그래밍 교실",
+  isRecruiting: false
+};
+
+const miniCard4 = {
+  leader: "dlatns0201@gmail.com",
+  img: "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
+  title: "30대의 뚝심을 버리는 법",
+  isRecruiting: true
+};
+const myStudyData = [miniCard1, miniCard2, miniCard3, miniCard4];
 const categoryData = [category, category, category, category, category];
 
 export { myStudyData, categoryData, studyGroupData };

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -8,6 +8,8 @@ const HeaderBox = styled.div`
   padding-left: 5%;
   padding-right: 5%;
   padding-top: 3%;
+  margin-bottom: 2.3rem;
+
   .logo {
     width: 64px;
     height: 64px;

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 
 const HeaderBox = styled.div`
   display: flex;
@@ -34,17 +35,21 @@ const Header = ({ uri }) => (
   <header>
     <HeaderBox>
       <a href={uri}>
-        <img src="/image/logo-mini.png" className={["logo"]}></img>
+        <img
+          src="/image/logo-mini.png"
+          alt="study combined"
+          className={["logo"]}
+        ></img>
       </a>
       <div className={`account-box`}>
         <div className={`signin-btn accountbox-btn `}>
-          <span>로그인</span>
+          <Link to="/partners/login"> 로그인 </Link>
         </div>
         <div className={`signout-btn accountbox-btn`}>
-          <span>회원가입</span>
+          <Link to="/partners/join"> 회원가입 </Link>
         </div>
         <div className={`user-account-btn accountbox-btn`}>
-          <span>{"Soob"} 님</span>
+          <span> 태현님 환영합니다. </span>
         </div>
       </div>
     </HeaderBox>

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -31,16 +31,16 @@ const HeaderBox = styled.div`
   }
 `;
 
-const Header = ({ uri }) => (
+const Header = () => (
   <header>
     <HeaderBox>
-      <a href={uri}>
+      <Link to="/">
         <img
           src="/image/logo-mini.png"
           alt="study combined"
           className={["logo"]}
-        ></img>
-      </a>
+        />{" "}
+      </Link>
       <div className={`account-box`}>
         <div className={`signin-btn accountbox-btn `}>
           <Link to="/partners/login"> 로그인 </Link>

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -42,12 +42,6 @@ const Header = () => (
         />{" "}
       </Link>
       <div className={`account-box`}>
-        <div className={`signin-btn accountbox-btn `}>
-          <Link to="/partners/login"> 로그인 </Link>
-        </div>
-        <div className={`signout-btn accountbox-btn`}>
-          <Link to="/partners/join"> 회원가입 </Link>
-        </div>
         <div className={`user-account-btn accountbox-btn`}>
           <span> 태현님 환영합니다. </span>
         </div>

--- a/client/src/components/MyStudyCarousel.jsx
+++ b/client/src/components/MyStudyCarousel.jsx
@@ -7,12 +7,14 @@ const Main = styled.div`
 // Import Bulma core
 @import 'bulma.sass'
 @import "bulmaCarousel.sass"
+//;
+
 
   .carousel-box{
     overflow:hidden;
-    padding: 3rem 1.5rem;
 
     .carousel{
+      height: 20rem;
       display:flex;
       justify-content:center;
 
@@ -20,6 +22,7 @@ const Main = styled.div`
         padding:0 5%;
       }
     }
+
     .my-group-title{
       font-weight:bold;
       font-size:1.5em;

--- a/client/src/components/MyStudyCarousel.jsx
+++ b/client/src/components/MyStudyCarousel.jsx
@@ -32,9 +32,9 @@ const Main = styled.div`
  
 `;
 
-const MyStudyCarousel = ({ myStudyData, user_email }) => {
+const MyStudyCarousel = ({ myGroups, user_email }) => {
   useEffect(() => {
-    if (myStudyData.length > 3)
+    if (myGroups.length > 3)
       bulmaCarousel.attach(".carousel", {
         slidesToScroll: 1,
         slidesToShow: 3,
@@ -46,14 +46,14 @@ const MyStudyCarousel = ({ myStudyData, user_email }) => {
     <Main>
       <div
         className="carousel-box"
-        style={{ overflow: "hidden", width: `${myStudyData.length * 15}em` }}
+        style={{ overflow: "hidden", width: `${myGroups.length * 15}em` }}
       >
         <div className="my-group-title">👨‍👨‍👧‍👦현재 함께하는 그룹이에요</div>
         <div className="carousel">
-          {myStudyData.map(study => {
+          {myGroups.map(group => {
             return (
               <div className="carousel-item">
-                <StudyGroupCardMini cardData={study} user_email={user_email} />
+                <StudyGroupCardMini cardData={group} user_email={user_email} />
               </div>
             );
           })}

--- a/client/src/components/MyStudyCarousel.jsx
+++ b/client/src/components/MyStudyCarousel.jsx
@@ -32,7 +32,7 @@ const Main = styled.div`
  
 `;
 
-const MyStudyCarousel = ({ myStudyData }) => {
+const MyStudyCarousel = ({ myStudyData, user_email }) => {
   useEffect(() => {
     if (myStudyData.length > 3)
       bulmaCarousel.attach(".carousel", {
@@ -53,7 +53,7 @@ const MyStudyCarousel = ({ myStudyData }) => {
           {myStudyData.map(study => {
             return (
               <div className="carousel-item">
-                <StudyGroupCardMini cardData={study} />
+                <StudyGroupCardMini cardData={study} user_email={user_email} />
               </div>
             );
           })}

--- a/client/src/components/MyStudyCarousel.jsx
+++ b/client/src/components/MyStudyCarousel.jsx
@@ -4,12 +4,6 @@ import StudyGroupCardMini from "./groupCardMini";
 import bulmaCarousel from "bulma-carousel/dist/js/bulma-carousel.min.js";
 
 const Main = styled.div`
-// Import Bulma core
-@import 'bulma.sass'
-@import "bulmaCarousel.sass"
-//;
-
-
   .carousel-box{
     overflow:hidden;
 

--- a/client/src/components/groupCard/index.jsx
+++ b/client/src/components/groupCard/index.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 import Thumbnail from "./Thumbnail";
 import Body from "./Body";
 import Footer from "./Footer";
@@ -23,11 +24,13 @@ const StyledCard = styled.div`
 `;
 
 const StudyGroupCard = ({ groupData }) => (
-  <StyledCard>
-    <Thumbnail src={groupData.src} alt={groupData.alt} />
-    <Body bodyData={{ ...groupData }} />
-    <Footer footerData={{ ...groupData }} />
-  </StyledCard>
+  <Link to={`/group/detail/${groupData.id}`}>
+    <StyledCard>
+      <Thumbnail src={groupData.src} alt={groupData.alt} />
+      <Body bodyData={{ ...groupData }} />
+      <Footer footerData={{ ...groupData }} />
+    </StyledCard>
+  </Link>
 );
 
 export default StudyGroupCard;

--- a/client/src/components/groupCardMini/index.jsx
+++ b/client/src/components/groupCardMini/index.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import Title from "../groupCard/Title";
+
 const StyledCard = styled.div`
   width: 15em;
   height: 15em;
@@ -41,13 +41,16 @@ const StyledCard = styled.div`
 `;
 
 const StudyGroupCardMini = ({
-  cardData: { isLeader, img, title, currentStudyCount, totalStudyCount }
+  cardData: { leader, img, title, isRecruiting },
+  user_email
 }) => {
+  const recruitingClass = isRecruiting ? "has-text-info" : "has-text-danger";
+
   return (
     <StyledCard className={`card study-mini-card`}>
       <div
         className="group-leader-bedge"
-        style={{ display: isLeader ? "block" : "none" }}
+        style={{ display: leader === user_email ? "block" : "none" }}
       >
         그룹장
       </div>
@@ -55,10 +58,9 @@ const StudyGroupCardMini = ({
         <img src={img}></img>
       </div>
       <div className={`title-small`}>{title}</div>
-      <div className={`progress-box`}>
-        <span className={`highlight`}>{currentStudyCount}</span>/
-        {totalStudyCount}회 진행중
-      </div>
+      <span className={`highlight ${recruitingClass}`}>
+        {isRecruiting ? "모집중" : "마감"}
+      </span>
     </StyledCard>
   );
 };

--- a/client/src/components/groupCardMini/index.jsx
+++ b/client/src/components/groupCardMini/index.jsx
@@ -18,6 +18,7 @@ const StyledCard = styled.div`
     font-size: 1.1em;
     text-align: center;
     margin: 1.3rem 1em;
+    height: 2.6rem;
     color: #1d6de4;
   }
   .progress-box {

--- a/client/src/components/groupCardMini/index.jsx
+++ b/client/src/components/groupCardMini/index.jsx
@@ -2,33 +2,34 @@ import React from "react";
 import styled from "styled-components";
 
 const StyledCard = styled.div`
-  width: 15em;
-  height: 15em;
+  width: 16rem;
+  margin: 1rem 0;
+  margin-left: 1rem;
+  height: 17em;
   display: flex;
   flex-direction: column;
   align-items: center;
   overflow: hidden;
+  padding-bottom: 0.5rem;
 
   .imgbox {
-    height: 45%;
+    max-height: 12rem;
     overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+    }
   }
   .title-small {
     font-weight: bold;
     font-size: 1.1em;
     text-align: center;
-    margin: 1.3rem 1em;
-    height: 2.6rem;
+    margin: auto 0.7em;
+    max-height: 7rem;
     color: #1d6de4;
   }
-  .progress-box {
-    font-weight: bold;
-    font-size: 0.8em;
-    .highlight {
-      color: #e41d60;
-      font-weight: bold;
-    }
-  }
+
   .group-leader-bedge {
     background-color: #e41d60;
     width: 5em;
@@ -42,11 +43,9 @@ const StyledCard = styled.div`
 `;
 
 const StudyGroupCardMini = ({
-  cardData: { leader, img, title, isRecruiting },
+  cardData: { leader, img, title },
   user_email
 }) => {
-  const recruitingClass = isRecruiting ? "has-text-info" : "has-text-danger";
-
   return (
     <StyledCard className={`card study-mini-card`}>
       <div
@@ -59,9 +58,6 @@ const StudyGroupCardMini = ({
         <img src={img}></img>
       </div>
       <div className={`title-small`}>{title}</div>
-      <span className={`highlight ${recruitingClass}`}>
-        {isRecruiting ? "모집중" : "마감"}
-      </span>
     </StyledCard>
   );
 };

--- a/client/src/components/groupCardMini/index.jsx
+++ b/client/src/components/groupCardMini/index.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 
 const StyledCard = styled.div`
   width: 16rem;
@@ -43,22 +44,24 @@ const StyledCard = styled.div`
 `;
 
 const StudyGroupCardMini = ({
-  cardData: { leader, img, title },
+  cardData: { leader, img, title, id },
   user_email
 }) => {
   return (
-    <StyledCard className={`card study-mini-card`}>
-      <div
-        className="group-leader-bedge"
-        style={{ display: leader === user_email ? "block" : "none" }}
-      >
-        그룹장
-      </div>
-      <div className={`imgbox`}>
-        <img src={img}></img>
-      </div>
-      <div className={`title-small`}>{title}</div>
-    </StyledCard>
+    <Link to={`/group/detail/${id}`}>
+      <StyledCard className={`card study-mini-card`}>
+        <div
+          className="group-leader-bedge"
+          style={{ display: leader === user_email ? "block" : "none" }}
+        >
+          그룹장
+        </div>
+        <div className={`imgbox`}>
+          <img src={img}></img>
+        </div>
+        <div className={`title-small`}>{title}</div>
+      </StyledCard>
+    </Link>
   );
 };
 

--- a/client/src/components/studySearchNavbar/StudyNavbarItem.jsx
+++ b/client/src/components/studySearchNavbar/StudyNavbarItem.jsx
@@ -9,11 +9,11 @@ const Category = styled.div`
   }
 `;
 
-const StudyNavbarItem = ({ data }) => {
-  const itemList = data.items.map(item => {
+const StudyNavbarItem = ({ primaryCategory, secondaryCategories }) => {
+  const itemList = secondaryCategories.map(category => {
     return (
-      <a class="navbar-item" href={item.href}>
-        {item.name}
+      <a class="navbar-item" href="www.naver.com">
+        {category}
       </a>
     );
   });
@@ -25,7 +25,7 @@ const StudyNavbarItem = ({ data }) => {
           class="navbar-link is-arrowless"
           href="https://bulma.io/documentation/overview/start/"
         >
-          {data.link}
+          {primaryCategory}
         </a>
         <div class="navbar-dropdown is-boxed">{itemList}</div>
       </div>

--- a/client/src/components/studySearchNavbar/StudyNavbarItem.jsx
+++ b/client/src/components/studySearchNavbar/StudyNavbarItem.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 
 const Category = styled.div`
   a {
@@ -12,21 +13,18 @@ const Category = styled.div`
 const StudyNavbarItem = ({ primaryCategory, secondaryCategories }) => {
   const itemList = secondaryCategories.map(category => {
     return (
-      <a class="navbar-item" href="www.naver.com">
+      <Link class="navbar-item" to={`/category/${category}`}>
         {category}
-      </a>
+      </Link>
     );
   });
 
   return (
     <Category>
       <div class="navbar-item has-dropdown is-hoverable">
-        <a
-          class="navbar-link is-arrowless"
-          href="https://bulma.io/documentation/overview/start/"
-        >
-          {primaryCategory}
-        </a>
+        <span class="navbar-link is-arrowless is-size-3">
+          {primaryCategory}{" "}
+        </span>
         <div class="navbar-dropdown is-boxed">{itemList}</div>
       </div>
     </Category>

--- a/client/src/components/studySearchNavbar/StudySearchNavbar.jsx
+++ b/client/src/components/studySearchNavbar/StudySearchNavbar.jsx
@@ -11,7 +11,7 @@ const Navbar = styled.div`
   }
 `;
 
-const StudySearchNavbar = ({ categoryData }) => (
+const StudySearchNavbar = ({ primaryCategories, secondaryCategories }) => (
   <Navbar>
     <nav
       class="navbar is-transparent"
@@ -20,8 +20,11 @@ const StudySearchNavbar = ({ categoryData }) => (
     >
       <div id="navbarExampleTransparentExample" style={{ width: "100%" }}>
         <div class="navbar-start">
-          {categoryData.map(data => (
-            <StudyNavbarItem data={data}></StudyNavbarItem>
+          {primaryCategories.map(category => (
+            <StudyNavbarItem
+              primaryCategory={category}
+              secondaryCategories={secondaryCategories[category]}
+            ></StudyNavbarItem>
           ))}
         </div>
       </div>

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -100,8 +100,8 @@ const MainPage = () => {
         secondaryCategories={secondaryCategories}
       ></StudySearchNavbar>
       <div className="study-group-list">
-        {cardList.map(data => {
-          return <StudyGroupCard groupData={data}></StudyGroupCard>;
+        {cardList.map(groupData => {
+          return <StudyGroupCard groupData={groupData}></StudyGroupCard>;
         })}
       </div>
     </Main>

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -84,7 +84,10 @@ const MainPage = () => {
     <Main>
       <div className="main-jumbotron">
         {user_email ? (
-          <MyStudyCarousel myStudyData={myStudyData}></MyStudyCarousel>
+          <MyStudyCarousel
+            myStudyData={myStudyData}
+            user_email={user_email}
+          ></MyStudyCarousel>
         ) : (
           <div className="main-page-title">
             <div className="main-title">스터디,</div>
@@ -95,6 +98,7 @@ const MainPage = () => {
           </div>
         )}
       </div>
+
       <StudySearchNavbar categoryData={categoryData}></StudySearchNavbar>
       <div className="study-group-list">
         {cardListData.map(data => {

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import styled from "styled-components";
 import StudySearchNavbar from "../../components/studySearchNavbar/StudySearchNavbar";
 import StudyGroupCard from "../../components/groupCard";
@@ -8,6 +8,7 @@ import {
   categoryData,
   myStudyData
 } from "../../__test__/mainPage.dummy";
+import { AppContext } from "../../App";
 
 const Main = styled.div`
   display: flex;
@@ -67,6 +68,10 @@ const MainPage = () => {
     studyGroupData
   ]);
 
+  const {
+    appState: { user_email }
+  } = useContext(AppContext);
+
   useEffect(() => {
     /**
      * TODO: data 요청로직 필요
@@ -78,14 +83,17 @@ const MainPage = () => {
   return (
     <Main>
       <div className="main-jumbotron">
-        <MyStudyCarousel myStudyData={myStudyData}></MyStudyCarousel>
-        <div className="main-page-title">
-          <div className="main-title">스터디,</div>
-          <div className="main-subtitle">
-            <span className="highlight">모집</span>부터{" "}
-            <span className="highlight">예약</span>까지 한번에-
+        {user_email ? (
+          <MyStudyCarousel myStudyData={myStudyData}></MyStudyCarousel>
+        ) : (
+          <div className="main-page-title">
+            <div className="main-title">스터디,</div>
+            <div className="main-subtitle">
+              <span className="highlight">모집</span>부터{" "}
+              <span className="highlight">예약</span>까지 한번에-
+            </div>
           </div>
-        </div>
+        )}
       </div>
       <StudySearchNavbar categoryData={categoryData}></StudySearchNavbar>
       <div className="study-group-list">

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -1,14 +1,10 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useReducer } from "react";
 import styled from "styled-components";
 import StudySearchNavbar from "../../components/studySearchNavbar/StudySearchNavbar";
 import StudyGroupCard from "../../components/groupCard";
 import MyStudyCarousel from "../../components/MyStudyCarousel";
-import {
-  studyGroupData,
-  categoryData,
-  myStudyData
-} from "../../__test__/mainPage.dummy";
 import { AppContext } from "../../App";
+import { initalState, mainReducer } from "../../reducer/Main";
 
 const Main = styled.div`
   display: flex;
@@ -60,13 +56,13 @@ const Main = styled.div`
  * 로그인시 MyStudyCarousel 출력
  */
 const MainPage = () => {
-  const [cardListData, setCardListData] = useState([
-    studyGroupData,
-    studyGroupData,
-    studyGroupData,
-    studyGroupData,
-    studyGroupData
-  ]);
+  const [mainState, mainDispatch] = useReducer(mainReducer, initalState);
+  const {
+    myGroups,
+    cardList,
+    primaryCategories,
+    secondaryCategories
+  } = mainState;
 
   const {
     appState: { user_email }
@@ -85,7 +81,7 @@ const MainPage = () => {
       <div className="main-jumbotron">
         {user_email ? (
           <MyStudyCarousel
-            myStudyData={myStudyData}
+            myGroups={myGroups}
             user_email={user_email}
           ></MyStudyCarousel>
         ) : (
@@ -99,9 +95,12 @@ const MainPage = () => {
         )}
       </div>
 
-      <StudySearchNavbar categoryData={categoryData}></StudySearchNavbar>
+      <StudySearchNavbar
+        primaryCategories={primaryCategories}
+        secondaryCategories={secondaryCategories}
+      ></StudySearchNavbar>
       <div className="study-group-list">
-        {cardListData.map(data => {
+        {cardList.map(data => {
           return <StudyGroupCard groupData={data}></StudyGroupCard>;
         })}
       </div>

--- a/client/src/reducer/App.jsx
+++ b/client/src/reducer/App.jsx
@@ -1,0 +1,5 @@
+export const initalState = {
+  user_email: "dlatns0201@gmail.com"
+};
+
+export const appReducer = (state, action) => {};

--- a/client/src/reducer/Main.jsx
+++ b/client/src/reducer/Main.jsx
@@ -11,7 +11,8 @@ export const initalState = {
       leader: "dlatns0202@gmail.com",
       img:
         "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
-      title: "HTML은 프로그래밍 언어가 아니다~",
+      title:
+        "HTML은 프로그래밍 언어가 아니다~HTML은 프로그래밍 언어가 아니다~HTML은 프로그래밍 언어가 아니다~",
       isRecruiting: false
     },
     {

--- a/client/src/reducer/Main.jsx
+++ b/client/src/reducer/Main.jsx
@@ -1,5 +1,5 @@
 export const initalState = {
-  miniCards: [
+  myGroups: [
     {
       leader: "dlatns0201@gmail.com",
       img:
@@ -28,7 +28,65 @@ export const initalState = {
       title: "30대의 뚝심을 버리는 법",
       isRecruiting: true
     }
-  ]
+  ],
+  cardList: [
+    {
+      src:
+        "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
+      alt: "img",
+      title: "필수 표현으로 마스터하는 비즈니스 영어",
+      subtitle:
+        "10여 년의 해외 근무 경험으로 쌓은 실전 비즈니스 영어 노하우를 배울 수 있는 스터디입니다.",
+      location: "강남",
+      time: "월수 | 20:00 ~ | 2시간",
+      nowCnt: 8,
+      maxCnt: 10
+    },
+    {
+      src:
+        "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
+      alt: "img",
+      title: "필수 표현으로 마스터하는 비즈니스 영어",
+      subtitle:
+        "10여 년의 해외 근무 경험으로 쌓은 실전 비즈니스 영어 노하우를 배울 수 있는 스터디입니다.",
+      location: "강남",
+      time: "월수 | 20:00 ~ | 2시간",
+      nowCnt: 8,
+      maxCnt: 10
+    },
+    {
+      src:
+        "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
+      alt: "img",
+      title: "필수 표현으로 마스터하는 비즈니스 영어",
+      subtitle:
+        "10여 년의 해외 근무 경험으로 쌓은 실전 비즈니스 영어 노하우를 배울 수 있는 스터디입니다.",
+      location: "강남",
+      time: "월수 | 20:00 ~ | 2시간",
+      nowCnt: 8,
+      maxCnt: 10
+    },
+    {
+      src:
+        "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
+      alt: "img",
+      title: "필수 표현으로 마스터하는 비즈니스 영어",
+      subtitle:
+        "10여 년의 해외 근무 경험으로 쌓은 실전 비즈니스 영어 노하우를 배울 수 있는 스터디입니다.",
+      location: "강남",
+      time: "월수 | 20:00 ~ | 2시간",
+      nowCnt: 8,
+      maxCnt: 10
+    }
+  ],
+  primaryCategories: ["프로그래밍", "자격증", "외국어", "면접", "지역"],
+  secondaryCategories: {
+    프로그래밍: ["C++", "Java", "JavaScript"],
+    자격증: ["IT", "운전", "보건", "식품"],
+    외국어: ["영어", "중국어", "불어", "스페인어"],
+    면접: ["공채", "상시채용", "특채", "기술면접", "임원면접"],
+    지역: ["경기도", "서울", "울산", "인천", "광주", "부산"]
+  }
 };
 
 export const mainReducer = (state, action) => {};

--- a/client/src/reducer/Main.jsx
+++ b/client/src/reducer/Main.jsx
@@ -1,0 +1,5 @@
+export const initalState = {
+  user_email: "dlatns0201@gmail.com"
+};
+
+export const mainReducer = (state, action) => {};

--- a/client/src/reducer/Main.jsx
+++ b/client/src/reducer/Main.jsx
@@ -1,6 +1,7 @@
 export const initalState = {
   myGroups: [
     {
+      id: 1,
       leader: "dlatns0201@gmail.com",
       img:
         "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
@@ -8,6 +9,7 @@ export const initalState = {
       isRecruiting: true
     },
     {
+      id: 2,
       leader: "dlatns0202@gmail.com",
       img:
         "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
@@ -16,6 +18,7 @@ export const initalState = {
       isRecruiting: false
     },
     {
+      id: 3,
       leader: "dlatns0202@gmail.com",
       img:
         "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
@@ -23,6 +26,7 @@ export const initalState = {
       isRecruiting: false
     },
     {
+      id: 4,
       leader: "dlatns0201@gmail.com",
       img:
         "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
@@ -32,6 +36,7 @@ export const initalState = {
   ],
   cardList: [
     {
+      id: 5,
       src:
         "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
       alt: "img",
@@ -44,6 +49,7 @@ export const initalState = {
       maxCnt: 10
     },
     {
+      id: 6,
       src:
         "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
       alt: "img",
@@ -56,6 +62,7 @@ export const initalState = {
       maxCnt: 10
     },
     {
+      id: 7,
       src:
         "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
       alt: "img",
@@ -68,6 +75,7 @@ export const initalState = {
       maxCnt: 10
     },
     {
+      id: 8,
       src:
         "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
       alt: "img",

--- a/client/src/reducer/Main.jsx
+++ b/client/src/reducer/Main.jsx
@@ -1,5 +1,34 @@
 export const initalState = {
-  user_email: "dlatns0201@gmail.com"
+  miniCards: [
+    {
+      leader: "dlatns0201@gmail.com",
+      img:
+        "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
+      title: "영화보면서 영어공부 같이해요~",
+      isRecruiting: true
+    },
+    {
+      leader: "dlatns0202@gmail.com",
+      img:
+        "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
+      title: "HTML은 프로그래밍 언어가 아니다~",
+      isRecruiting: false
+    },
+    {
+      leader: "dlatns0202@gmail.com",
+      img:
+        "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
+      title: "김세진도 좋아하는 Java 프로그래밍 교실",
+      isRecruiting: false
+    },
+    {
+      leader: "dlatns0201@gmail.com",
+      img:
+        "http://images.christiantoday.co.kr/data/images/full/323947/2.jpg?w=654",
+      title: "30대의 뚝심을 버리는 법",
+      isRecruiting: true
+    }
+  ]
 };
 
 export const mainReducer = (state, action) => {};


### PR DESCRIPTION
# 구현 내용
- Carousel CSS 약간 수정
- 카테고리, 내 그룹 정보, 탐색 그룹 정보를 Reducer에 저장
- 헤더, 카테고리, 내 그룹 카드, 탐색 그룹 카드에 Link를 사용해 라우팅 적용
- 전역 상태 관리 전용 Reducer 작성, Context API로 사용자 정보를 뿌려줌
- Context Api를 통해 점보트론과 내 그룹 정보 중 선택해서 렌더링
- 이 밖에 필요없는 코드 제거
