### PR TITLE
검색 서비스와 메인 페이지 연동

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "@commitlint/cli": "^7.5.2",
     "@commitlint/config-conventional": "^7.5.0",
     "ajv": "^6.8.1",
+    "axios": "^0.19.0",
     "bulma-carousel": "^4.0.4",
     "classnames": "^2.2.6",
     "husky": "^1.3.1",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,8 +25,8 @@ function App() {
         <AppContext.Provider value={{ appState, appDispatch }}>
           <Header />
           <Switch>
-            <Route path="/" exact component={MainPage} />
             <Route path="/group/create" component={GroupCreatePage} />
+            <Route path="/" component={MainPage} />
             <Route
               render={({ location }) => (
                 <div>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,6 +3,7 @@ import { Route, Switch, BrowserRouter as Router } from "react-router-dom";
 import { createGlobalStyle } from "styled-components";
 import Header from "./components/Header";
 import MainPage from "./pages/users/Main";
+import GroupCreatePage from "./pages/users/groupCreate";
 import { initalState, appReducer } from "./reducer/App";
 
 const GlobalStyle = createGlobalStyle`
@@ -25,6 +26,7 @@ function App() {
           <Header />
           <Switch>
             <Route path="/" exact component={MainPage} />
+            <Route path="/group/create" component={GroupCreatePage} />
             <Route
               render={({ location }) => (
                 <div>

--- a/client/src/components/groupCard/Footer.jsx
+++ b/client/src/components/groupCard/Footer.jsx
@@ -23,7 +23,7 @@ const Footer = ({
 }) => {
   const time = `${days
     .map(dayNumber => days_char[dayNumber])
-    .join(", ")} | ${startTime}:00 시작 | ${during}시간 }`;
+    .join(", ")} | ${startTime}:00 시작 | ${during}시간 `;
 
   return (
     <StyledFooter>

--- a/client/src/components/groupCard/Footer.jsx
+++ b/client/src/components/groupCard/Footer.jsx
@@ -9,11 +9,13 @@ const StyledFooter = styled.div`
   padding: 0 1rem;
 `;
 
-const Footer = ({ footerData: { location, time, nowCnt, maxCnt } }) => (
+const Footer = ({
+  footerData: { location, time, now_personnel, max_personnel }
+}) => (
   <StyledFooter>
     <Location location={location} />
     <TimeInfo time={time} />
-    <Personnel nowCnt={nowCnt} maxCnt={maxCnt} />
+    <Personnel now_personnel={now_personnel} max_personnel={max_personnel} />
   </StyledFooter>
 );
 

--- a/client/src/components/groupCard/Footer.jsx
+++ b/client/src/components/groupCard/Footer.jsx
@@ -9,14 +9,29 @@ const StyledFooter = styled.div`
   padding: 0 1rem;
 `;
 
+const days_char = ["일", "월", "화", "수", "목", "금", "토"];
+
 const Footer = ({
-  footerData: { location, time, now_personnel, max_personnel }
-}) => (
-  <StyledFooter>
-    <Location location={location} />
-    <TimeInfo time={time} />
-    <Personnel now_personnel={now_personnel} max_personnel={max_personnel} />
-  </StyledFooter>
-);
+  footerData: {
+    location,
+    startTime,
+    during,
+    days,
+    now_personnel,
+    max_personnel
+  }
+}) => {
+  const time = `${days
+    .map(dayNumber => days_char[dayNumber])
+    .join(", ")} | ${startTime}:00 시작 | ${during}시간 }`;
+
+  return (
+    <StyledFooter>
+      <Location location={location} />
+      <TimeInfo time={time} />
+      <Personnel now_personnel={now_personnel} max_personnel={max_personnel} />
+    </StyledFooter>
+  );
+};
 
 export default Footer;

--- a/client/src/components/groupCard/Personnel.jsx
+++ b/client/src/components/groupCard/Personnel.jsx
@@ -8,9 +8,9 @@ const Personnel = styled.div`
   }
 `;
 
-const StudyPersonnel = ({ nowCnt, maxCnt }) => (
+const StudyPersonnel = ({ now_personnel, max_personnel }) => (
   <Personnel>
-    <span className={`now-count`}>{nowCnt}</span>/{maxCnt}명
+    <span className={`now-count`}>{now_personnel}</span>/{max_personnel}명
   </Personnel>
 );
 

--- a/client/src/components/groupCard/index.jsx
+++ b/client/src/components/groupCard/index.jsx
@@ -6,31 +6,35 @@ import Body from "./Body";
 import Footer from "./Footer";
 
 const StyledCard = styled.div`
-  display: flex;
-  margin: 3em 2em;
-  flex-direction: column;
-  font-family: "Nanum Gothic", sans-serif;
-  font-weight: bold;
+  .card {
+    display: flex;
+    margin: 2.4em 0 1rem 0;
+    flex-direction: column;
+    font-family: "Nanum Gothic", sans-serif;
+    font-weight: bold;
 
-  width: 19rem;
-  height: 32rem;
-  background-color: whitesmoke;
-  border-radius: 0.2rem;
-  padding-bottom: 1.3rem;
-  box-shadow: 0 17px 30px 0 rgba(0, 0, 0, 0.2);
-  &:hover {
-    box-shadow: none;
+    width: 19rem;
+    height: 32rem;
+    background-color: whitesmoke;
+    border-radius: 0.2rem;
+    padding-bottom: 1.3rem;
+    box-shadow: 0 17px 30px 0 rgba(0, 0, 0, 0.2);
+    &:hover {
+      box-shadow: none;
+    }
   }
 `;
 
 const StudyGroupCard = ({ groupData }) => (
-  <Link to={`/group/detail/${groupData.id}`}>
-    <StyledCard>
-      <Thumbnail src={groupData.src} alt={groupData.alt} />
-      <Body bodyData={{ ...groupData }} />
-      <Footer footerData={{ ...groupData }} />
-    </StyledCard>
-  </Link>
+  <StyledCard className="card-wrapper">
+    <Link to={`/group/detail/${groupData.id}`}>
+      <div className="card">
+        <Thumbnail src={groupData.src} alt={groupData.alt} />
+        <Body bodyData={{ ...groupData }} />
+        <Footer footerData={{ ...groupData }} />
+      </div>
+    </Link>
+  </StyledCard>
 );
 
 export default StudyGroupCard;

--- a/client/src/components/groupCard/index.jsx
+++ b/client/src/components/groupCard/index.jsx
@@ -29,7 +29,7 @@ const StudyGroupCard = ({ groupData }) => (
   <StyledCard className="card-wrapper">
     <Link to={`/group/detail/${groupData.id}`}>
       <div className="card">
-        <Thumbnail src={groupData.src} alt={groupData.alt} />
+        <Thumbnail src={groupData.thumbnail} alt={groupData.alt} />
         <Body bodyData={{ ...groupData }} />
         <Footer footerData={{ ...groupData }} />
       </div>

--- a/client/src/components/studySearchNavbar/StudyNavbarItem.jsx
+++ b/client/src/components/studySearchNavbar/StudyNavbarItem.jsx
@@ -11,21 +11,19 @@ const Category = styled.div`
 `;
 
 const StudyNavbarItem = ({ primaryCategory, secondaryCategories }) => {
-  const itemList = secondaryCategories.map(category => {
-    return (
-      <Link class="navbar-item" to={`/category/${category}`}>
-        {category}
-      </Link>
-    );
-  });
+  const itemList = secondaryCategories.map(category => (
+    <Link className="navbar-item" to={`/category/${category}`}>
+      {category}
+    </Link>
+  ));
 
   return (
     <Category>
-      <div class="navbar-item has-dropdown is-hoverable">
-        <span class="navbar-link is-arrowless is-size-3">
-          {primaryCategory}{" "}
+      <div className="navbar-item has-dropdown is-hoverable">
+        <span className="navbar-link is-arrowless is-size-3">
+          {primaryCategory}
         </span>
-        <div class="navbar-dropdown is-boxed">{itemList}</div>
+        <div className="navbar-dropdown is-boxed">{itemList}</div>
       </div>
     </Category>
   );

--- a/client/src/components/studySearchNavbar/StudySearchNavbar.jsx
+++ b/client/src/components/studySearchNavbar/StudySearchNavbar.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 import StudyNavbarItem from "./StudyNavbarItem";
 const Navbar = styled.div`
   padding: 5%;
@@ -9,17 +10,27 @@ const Navbar = styled.div`
     justify-content: space-around;
     width: 100%;
   }
+
+  a {
+    font-family: "Nanum Gothic", sans-serif;
+    font-weight: bold;
+    font-size: 1.7em;
+  }
 `;
 
 const StudySearchNavbar = ({ primaryCategories, secondaryCategories }) => (
   <Navbar>
     <nav
-      class="navbar is-transparent"
+      className="navbar is-transparent"
       role="navigation"
       aria-label="dropdown navigation"
     >
       <div id="navbarExampleTransparentExample" style={{ width: "100%" }}>
-        <div class="navbar-start">
+        <div className="navbar-start">
+          <Link className="navbar-item" to="/">
+            모두 보기
+          </Link>
+
           {primaryCategories.map(category => (
             <StudyNavbarItem
               primaryCategory={category}

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useContext, useReducer } from "react";
 import styled from "styled-components";
 import { Link, Route, BrowserRouter as Router } from "react-router-dom";
+import axios from "axios";
 import StudySearchNavbar from "../../components/studySearchNavbar/StudySearchNavbar";
 import StudyGroupCard from "../../components/groupCard";
 import MyStudyCarousel from "../../components/MyStudyCarousel";
 import { AppContext } from "../../App";
-import { initalState, mainReducer } from "../../reducer/Main";
+import { initalState, mainReducer, get_all_groups } from "../../reducer/Main";
 
 const Main = styled.div`
   display: flex;
@@ -63,8 +64,11 @@ const Main = styled.div`
  * 미로그인시main-page-title 출력
  * 로그인시 MyStudyCarousel 출력
  */
+const searchUrl = "";
+
 const MainPage = () => {
   const [mainState, mainDispatch] = useReducer(mainReducer, initalState);
+
   const {
     myGroups,
     cardList,
@@ -77,6 +81,9 @@ const MainPage = () => {
   } = useContext(AppContext);
 
   useEffect(() => {
+    axios.get(searchUrl).then(data => {
+      mainDispatch(get_all_groups(data.data));
+    }, []);
     // /api/search/all
     /**
      * TODO: data 요청로직 필요

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext, useReducer } from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
+import { Link, Route, BrowserRouter as Router } from "react-router-dom";
 import StudySearchNavbar from "../../components/studySearchNavbar/StudySearchNavbar";
 import StudyGroupCard from "../../components/groupCard";
 import MyStudyCarousel from "../../components/MyStudyCarousel";
@@ -107,15 +107,31 @@ const MainPage = () => {
         )}
       </div>
 
-      <StudySearchNavbar
-        primaryCategories={primaryCategories}
-        secondaryCategories={secondaryCategories}
-      ></StudySearchNavbar>
-      <div className="study-group-list">
-        {cardList.map(groupData => {
-          return <StudyGroupCard groupData={groupData}></StudyGroupCard>;
-        })}
-      </div>
+      <Router>
+        <StudySearchNavbar
+          primaryCategories={primaryCategories}
+          secondaryCategories={secondaryCategories}
+        ></StudySearchNavbar>
+        <Route
+          path="/category/:categoryName"
+          render={({ match }) => {
+            const selectedCategory = match.params.categoryName;
+            const groupsData = cardList.filter(
+              card => card.category[1] === selectedCategory
+            );
+
+            return (
+              <div className="study-group-list">
+                {groupsData.map(groupData => {
+                  return (
+                    <StudyGroupCard groupData={groupData}></StudyGroupCard>
+                  );
+                })}
+              </div>
+            );
+          }}
+        />
+      </Router>
     </Main>
   );
 };

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -42,14 +42,16 @@ const Main = styled.div`
   }
 
   .study-group-list{
-    align-self:center;
-      background-color: #f8f0ee;
+      align-self:center;
+
       display: flex;
-      width: 70rem;
+      flex-direction: row;
+      justify-content: space-evenly;
+
+      background-color: #f8f0ee;
+      width: 75rem;
       flex-wrap: wrap;
-      padding: 4em;
       margin:0 10%;
-      justify-content: center;
       .study-group-card{
           margin: 2em;
       }

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useContext, useReducer } from "react";
+import React, { useEffect, useContext, useReducer } from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 import StudySearchNavbar from "../../components/studySearchNavbar/StudySearchNavbar";
 import StudyGroupCard from "../../components/groupCard";
 import MyStudyCarousel from "../../components/MyStudyCarousel";
@@ -17,6 +18,10 @@ const Main = styled.div`
     display:flex;
     flex-direction:column;
     align-items:center;
+
+    .group-create-button {
+      margin-top: 2rem;
+    }
   }
 
   .main-page-title{
@@ -69,6 +74,7 @@ const MainPage = () => {
   } = useContext(AppContext);
 
   useEffect(() => {
+    // /api/search/all
     /**
      * TODO: data 요청로직 필요
      * cardListData
@@ -80,10 +86,16 @@ const MainPage = () => {
     <Main>
       <div className="main-jumbotron">
         {user_email ? (
-          <MyStudyCarousel
-            myGroups={myGroups}
-            user_email={user_email}
-          ></MyStudyCarousel>
+          <>
+            <MyStudyCarousel
+              myGroups={myGroups}
+              user_email={user_email}
+            ></MyStudyCarousel>
+            <Link to="/group/create" className="group-create-button">
+              {" "}
+              <button className="button"> 그룹 생성 </button>
+            </Link>
+          </>
         ) : (
           <div className="main-page-title">
             <div className="main-title">스터디,</div>

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -81,8 +81,16 @@ const MainPage = () => {
   } = useContext(AppContext);
 
   useEffect(() => {
-    axios.get(searchUrl).then(data => {
-      mainDispatch(get_all_groups(data.data));
+    axios.get(searchUrl).then(result => {
+      const { data } = result;
+
+      for (let i = 0; i < data.length; i++) {
+        data[i].id = i;
+        data[
+          i
+        ].location = `위도: ${data[i].location.lat}, 경도: ${data[i].location.lon}`;
+      }
+      mainDispatch(get_all_groups(data));
     }, []);
     // /api/search/all
     /**

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -45,6 +45,7 @@ const Main = styled.div`
     align-self:center;
       background-color: #f8f0ee;
       display: flex;
+      width: 70rem;
       flex-wrap: wrap;
       padding: 4em;
       margin:0 10%;
@@ -113,12 +114,16 @@ const MainPage = () => {
           secondaryCategories={secondaryCategories}
         ></StudySearchNavbar>
         <Route
-          path="/category/:categoryName"
+          path={["/category/:categoryName", "/"]}
           render={({ match }) => {
             const selectedCategory = match.params.categoryName;
-            const groupsData = cardList.filter(
-              card => card.category[1] === selectedCategory
-            );
+            const pathName = match.path;
+            const groupsData =
+              pathName === "/"
+                ? cardList
+                : cardList.filter(
+                    card => card.category[1] === selectedCategory
+                  );
 
             return (
               <div className="study-group-list">

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -141,14 +141,17 @@ const MainPage = () => {
                 : cardList.filter(
                     card => card.category[1] === selectedCategory
                   );
+            const groupsDataLength = groupsData.length;
 
             return (
               <div className="study-group-list">
-                {groupsData.map(groupData => {
-                  return (
-                    <StudyGroupCard groupData={groupData}></StudyGroupCard>
-                  );
-                })}
+                {groupsDataLength
+                  ? groupsData.map(groupData => {
+                      return (
+                        <StudyGroupCard groupData={groupData}></StudyGroupCard>
+                      );
+                    })
+                  : "데이터가 업소용"}
               </div>
             );
           }}

--- a/client/src/reducer/Main.jsx
+++ b/client/src/reducer/Main.jsx
@@ -40,39 +40,39 @@ export const initalState = {
       src:
         "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
       alt: "img",
-      title: "필수 표현으로 마스터하는 비즈니스 영어",
-      subtitle:
-        "10여 년의 해외 근무 경험으로 쌓은 실전 비즈니스 영어 노하우를 배울 수 있는 스터디입니다.",
+      title: "숙련된 프로그래머",
+      subtitle: "자바스크립트의 풀 스택을 익히는 고오급 과정",
+      category: ["프로그래밍", "JavaScript"],
       location: "강남",
       time: "월수 | 20:00 ~ | 2시간",
-      nowCnt: 8,
-      maxCnt: 10
+      now_personnel: 8,
+      max_personnel: 10
     },
     {
       id: 6,
       src:
         "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
       alt: "img",
-      title: "필수 표현으로 마스터하는 비즈니스 영어",
-      subtitle:
-        "10여 년의 해외 근무 경험으로 쌓은 실전 비즈니스 영어 노하우를 배울 수 있는 스터디입니다.",
+      title: "초보자도 하는 코딩",
+      subtitle: "프로그래밍 언어의 기본인 C부터 근래에 핫한 Python 까지!",
+      category: ["프로그래밍", "C++"],
       location: "강남",
       time: "월수 | 20:00 ~ | 2시간",
-      nowCnt: 8,
-      maxCnt: 10
+      now_personnel: 8,
+      max_personnel: 10
     },
     {
       id: 7,
       src:
         "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
       alt: "img",
-      title: "필수 표현으로 마스터하는 비즈니스 영어",
-      subtitle:
-        "10여 년의 해외 근무 경험으로 쌓은 실전 비즈니스 영어 노하우를 배울 수 있는 스터디입니다.",
+      title: "컴퓨터활용능력 1급",
+      subtitle: "1달만에 습득하는 컴퓨터 활용 능력!",
+      category: ["자격증", "IT"],
       location: "강남",
       time: "월수 | 20:00 ~ | 2시간",
-      nowCnt: 8,
-      maxCnt: 10
+      now_personnel: 8,
+      max_personnel: 10
     },
     {
       id: 8,
@@ -82,19 +82,19 @@ export const initalState = {
       title: "필수 표현으로 마스터하는 비즈니스 영어",
       subtitle:
         "10여 년의 해외 근무 경험으로 쌓은 실전 비즈니스 영어 노하우를 배울 수 있는 스터디입니다.",
+      category: ["외국어", "영어"],
       location: "강남",
       time: "월수 | 20:00 ~ | 2시간",
-      nowCnt: 8,
-      maxCnt: 10
+      now_personnel: 8,
+      max_personnel: 10
     }
   ],
-  primaryCategories: ["프로그래밍", "자격증", "외국어", "면접", "지역"],
+  primaryCategories: ["프로그래밍", "자격증", "외국어", "면접"],
   secondaryCategories: {
     프로그래밍: ["C++", "Java", "JavaScript"],
     자격증: ["IT", "운전", "보건", "식품"],
     외국어: ["영어", "중국어", "불어", "스페인어"],
-    면접: ["공채", "상시채용", "특채", "기술면접", "임원면접"],
-    지역: ["경기도", "서울", "울산", "인천", "광주", "부산"]
+    면접: ["공채", "상시채용", "특채", "기술면접", "임원면접"]
   }
 };
 

--- a/client/src/reducer/Main.jsx
+++ b/client/src/reducer/Main.jsx
@@ -38,7 +38,7 @@ export const initalState = {
     {
       id: 5,
       src:
-        "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
+        "https://cdn.searchenginejournal.com/wp-content/uploads/2018/07/SEO-and-JavaScript-6-Things-You-Need-to-Know.webp",
       alt: "img",
       title: "숙련된 프로그래머",
       subtitle: "자바스크립트의 풀 스택을 익히는 고오급 과정",
@@ -50,8 +50,7 @@ export const initalState = {
     },
     {
       id: 6,
-      src:
-        "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
+      src: "https://gaussian37.github.io/assets/img/cpp/cpp.png",
       alt: "img",
       title: "초보자도 하는 코딩",
       subtitle: "프로그래밍 언어의 기본인 C부터 근래에 핫한 Python 까지!",
@@ -64,7 +63,7 @@ export const initalState = {
     {
       id: 7,
       src:
-        "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
+        "https://www.tippingkorea.co.kr/data/plupload/o_1ceqams87pgg1mf99v917r1r8ua.jpg",
       alt: "img",
       title: "컴퓨터활용능력 1급",
       subtitle: "1달만에 습득하는 컴퓨터 활용 능력!",
@@ -77,7 +76,7 @@ export const initalState = {
     {
       id: 8,
       src:
-        "https://nicholashowlett.com.au/wp-content/uploads/2016/05/coding-cat-768x512.jpg",
+        "http://static.news.zumst.com/images/68/2018/01/30/b74910f08a4f46bd81c3faf04a022424.jpg",
       alt: "img",
       title: "필수 표현으로 마스터하는 비즈니스 영어",
       subtitle:

--- a/client/src/reducer/Main.jsx
+++ b/client/src/reducer/Main.jsx
@@ -1,3 +1,10 @@
+export const GET_ALL_GROUPS = "main/GET_ALL_GROUPS";
+
+export const get_all_groups = cardList => ({
+  type: GET_ALL_GROUPS,
+  cardList
+});
+
 export const initalState = {
   myGroups: [
     {
@@ -97,4 +104,16 @@ export const initalState = {
   }
 };
 
-export const mainReducer = (state, action) => {};
+export const mainReducer = (state, action) => {
+  switch (action.type) {
+    case GET_ALL_GROUPS:
+      const { cardList } = action;
+      return {
+        ...state,
+        cardList
+      };
+
+    default:
+      return state;
+  }
+};

--- a/client/src/reducer/Main.jsx
+++ b/client/src/reducer/Main.jsx
@@ -44,45 +44,51 @@ export const initalState = {
   cardList: [
     {
       id: 5,
-      src:
+      thumbnail:
         "https://cdn.searchenginejournal.com/wp-content/uploads/2018/07/SEO-and-JavaScript-6-Things-You-Need-to-Know.webp",
       alt: "img",
       title: "숙련된 프로그래머",
       subtitle: "자바스크립트의 풀 스택을 익히는 고오급 과정",
       category: ["프로그래밍", "JavaScript"],
       location: "강남",
-      time: "월수 | 20:00 ~ | 2시간",
+      days: [1, 3],
+      startTime: 20,
+      during: 2,
       now_personnel: 8,
       max_personnel: 10
     },
     {
       id: 6,
-      src: "https://gaussian37.github.io/assets/img/cpp/cpp.png",
+      thumbnail: "https://gaussian37.github.io/assets/img/cpp/cpp.png",
       alt: "img",
       title: "초보자도 하는 코딩",
       subtitle: "프로그래밍 언어의 기본인 C부터 근래에 핫한 Python 까지!",
       category: ["프로그래밍", "C++"],
       location: "강남",
-      time: "월수 | 20:00 ~ | 2시간",
+      days: [1, 3],
+      startTime: 20,
+      during: 2,
       now_personnel: 8,
       max_personnel: 10
     },
     {
       id: 7,
-      src:
+      thumbnail:
         "https://www.tippingkorea.co.kr/data/plupload/o_1ceqams87pgg1mf99v917r1r8ua.jpg",
       alt: "img",
       title: "컴퓨터활용능력 1급",
       subtitle: "1달만에 습득하는 컴퓨터 활용 능력!",
       category: ["자격증", "IT"],
       location: "강남",
-      time: "월수 | 20:00 ~ | 2시간",
+      days: [1, 3],
+      startTime: 20,
+      during: 2,
       now_personnel: 8,
       max_personnel: 10
     },
     {
       id: 8,
-      src:
+      thumbnail:
         "http://static.news.zumst.com/images/68/2018/01/30/b74910f08a4f46bd81c3faf04a022424.jpg",
       alt: "img",
       title: "필수 표현으로 마스터하는 비즈니스 영어",
@@ -90,7 +96,9 @@ export const initalState = {
         "10여 년의 해외 근무 경험으로 쌓은 실전 비즈니스 영어 노하우를 배울 수 있는 스터디입니다.",
       category: ["외국어", "영어"],
       location: "강남",
-      time: "월수 | 20:00 ~ | 2시간",
+      days: [1, 3],
+      startTime: 20,
+      during: 2,
       now_personnel: 8,
       max_personnel: 10
     }


### PR DESCRIPTION
# 구현 내용
- 서버로 데이터를 요청한 뒤, reducer의 state를 dispatch
- dispatch한 state를 바탕으로 탐색할 카드 리스트 구현
-  카테고리별 라우팅으로, 리스트를 프론트단에서 필터링
- db 스키마에 맞게 일부 목업 상태 데이터의 속성명 변경
- 일부 스타일 변경(필터된 카드 리스트 컨테이너 등)
- 지역 카테고리 버튼 삭제
- 모두 보기 카테고리 버튼 추가
