### PR TITLE
구조 리팩토링한 후의 메인 페이지 정리

### DIFF
--- a/client/src/components/users/Header.jsx
+++ b/client/src/components/users/Header.jsx
@@ -9,41 +9,45 @@ import { set_groups } from "../../reducer/users/index";
 import { UserContext } from "../../pages/users/index";
 
 const StyledHeader = styled.header`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-left: 5%;
-  padding-right: 5%;
-  padding-top: 3%;
-  margin-bottom: 2.3rem;
-  .logo {
-    width: 64px;
-    height: 64px;
-  }
-  .search-box {
-    width: 70%;
-    .input {
-      border-color: #53d0ec;
-      width: 50%;
-    }
-  }
-  .account-box {
+  .header-info {
     display: flex;
-    font-family: NanumGothic;
-    font-weight: bold;
-    font-size: 1.3em;
-    color: #000000;
-    .accountbox-btn {
-      padding: 0 0.4em;
+    align-items: center;
+    justify-content: space-between;
+    padding-left: 5%;
+    padding-right: 5%;
+    padding-top: 3%;
+    margin-bottom: 2.3rem;
+
+    .logo {
+      width: 64px;
+      height: 64px;
     }
-    .user-account-btn {
-      color: #55f4c4;
+    .search-box {
+      width: 70%;
+      .input {
+        border-color: #53d0ec;
+        width: 50%;
+      }
+    }
+    .account-box {
+      display: flex;
+      font-family: NanumGothic;
+      font-weight: bold;
+      font-size: 1.3em;
+      color: #000000;
+      .accountbox-btn {
+        padding: 0 0.4em;
+      }
+      .user-account-btn {
+        color: #55f4c4;
+      }
     }
   }
 `;
 
 const Header = () => {
-  const { userIndexDispatch } = useContext(UserContext);
+  const { userInfo, userIndexDispatch } = useContext(UserContext);
+  const { userName } = { userInfo };
 
   const onKeyUp = useCallback(e => {
     if (e.key === "Enter") {
@@ -88,27 +92,27 @@ const Header = () => {
 
   return (
     <StyledHeader>
-      <Link to="/">
+      <div className="header-info">
         <img
           src="/image/logo-mini.png"
           alt="study combined"
           className={["logo"]}
         />{" "}
-      </Link>
-      <div className={`search-box`}>
-        <input
-          class="input is-rounded"
-          type="text"
-          placeholder="스터디그룹 검색"
-          onKeyUp={onKeyUp}
-        />
-      </div>
-      <div className={`account-box`}>
-        <div className={`user-account-btn accountbox-btn`}>
-          <span> 태현님 환영합니다. </span>
+        <div className={`search-box`}>
+          <input
+            class="input is-rounded"
+            type="text"
+            placeholder="스터디그룹 검색"
+            onKeyUp={onKeyUp}
+          />
         </div>
+        <div className={`account-box`}>
+          <div className={`user-account-btn accountbox-btn`}>
+            <span> {userName}님 환영합니다. </span>
+          </div>
+        </div>
+        <AccountContainer />
       </div>
-      <AccountContainer />
       <StudySearchNavbar />
     </StyledHeader>
   );

--- a/client/src/components/users/Header.jsx
+++ b/client/src/components/users/Header.jsx
@@ -3,11 +3,12 @@ import styled from "styled-components";
 import { Link } from "react-router-dom";
 import axios from "axios";
 import { REQUEST_URL } from "../../config.json";
+import StudySearchNavbar from "./studySearchNavbar";
 import AccountContainer from "./accountContainer";
 import { set_groups } from "../../reducer/users/index";
 import { UserContext } from "../../pages/users/index";
 
-const HeaderContainer = styled.header`
+const StyledHeader = styled.header`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -86,7 +87,7 @@ const Header = () => {
   }, []);
 
   return (
-    <HeaderContainer>
+    <StyledHeader>
       <Link to="/">
         <img
           src="/image/logo-mini.png"
@@ -108,7 +109,8 @@ const Header = () => {
         </div>
       </div>
       <AccountContainer />
-    </HeaderContainer>
+      <StudySearchNavbar />
+    </StyledHeader>
   );
 };
 

--- a/client/src/components/users/Header.jsx
+++ b/client/src/components/users/Header.jsx
@@ -100,7 +100,7 @@ const Header = () => {
         />{" "}
         <div className={`search-box`}>
           <input
-            class="input is-rounded"
+            className="input is-rounded"
             type="text"
             placeholder="스터디그룹 검색"
             onKeyUp={onKeyUp}

--- a/client/src/components/users/Header.jsx
+++ b/client/src/components/users/Header.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useContext } from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
 import axios from "axios";
 import { REQUEST_URL } from "../../config.json";
 import StudySearchNavbar from "./studySearchNavbar";
@@ -93,11 +92,13 @@ const Header = () => {
   return (
     <StyledHeader>
       <div className="header-info">
-        <img
-          src="/image/logo-mini.png"
-          alt="study combined"
-          className={["logo"]}
-        />{" "}
+        <a href="/">
+          <img
+            src="/image/logo-mini.png"
+            alt="study combined"
+            className="logo"
+          />{" "}
+        </a>
         <div className={`search-box`}>
           <input
             className="input is-rounded"

--- a/client/src/components/users/common/Location.jsx
+++ b/client/src/components/users/common/Location.jsx
@@ -28,13 +28,20 @@ const StyledLocation = styled.div`
   }
 `;
 
-const Location = ({ location }) => (
-  <StyledLocation>
-    <div className="imageWrapper">
-      <img src="/image/location-icon.png" alt="location-icon" />
-    </div>
-    <div className="locationName">&nbsp;{location}</div>
-  </StyledLocation>
-);
+const Location = ({ location }) => {
+  const { lat, lon } = location;
+
+  return (
+    <StyledLocation>
+      <div className="imageWrapper">
+        <img src="/image/location-icon.png" alt="location-icon" />
+      </div>
+      <div className="locationName">
+        {" "}
+        위도: {lat} 경도: {lon}
+      </div>
+    </StyledLocation>
+  );
+};
 
 export default memo(Location);

--- a/client/src/components/users/groupCard/Footer.jsx
+++ b/client/src/components/users/groupCard/Footer.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import TagButtons from "../common/TagButtons";
 import Location from "../common/Location";
 import TimeInfo from "./Time";
 import Personnel from "./Personnel";
@@ -18,7 +19,8 @@ const Footer = ({
     during,
     days,
     now_personnel,
-    max_personnel
+    max_personnel,
+    tags
   }
 }) => {
   const time = `${days
@@ -27,6 +29,7 @@ const Footer = ({
 
   return (
     <StyledFooter>
+      <TagButtons tags={tags} />
       <Location location={location} />
       <TimeInfo time={time} />
       <Personnel now_personnel={now_personnel} max_personnel={max_personnel} />

--- a/client/src/components/users/groupCard/Footer.jsx
+++ b/client/src/components/users/groupCard/Footer.jsx
@@ -10,8 +10,6 @@ const StyledFooter = styled.div`
   padding: 0 1rem;
 `;
 
-const days_char = ["일", "월", "화", "수", "목", "금", "토"];
-
 const Footer = ({
   footerData: {
     location,
@@ -23,15 +21,11 @@ const Footer = ({
     tags
   }
 }) => {
-  const time = `${days
-    .map(dayNumber => days_char[dayNumber])
-    .join(", ")} | ${startTime}:00 시작 | ${during}시간 `;
-
   return (
     <StyledFooter>
       <TagButtons tags={tags} />
       <Location location={location} />
-      <TimeInfo time={time} />
+      <TimeInfo days={days} startTime={startTime} during={during} />
       <Personnel now_personnel={now_personnel} max_personnel={max_personnel} />
     </StyledFooter>
   );

--- a/client/src/components/users/groupCard/Time.jsx
+++ b/client/src/components/users/groupCard/Time.jsx
@@ -5,6 +5,13 @@ const StyledStudyTime = styled.div`
   font-size: 1.1em;
 `;
 
-const StudyTime = ({ time }) => <StyledStudyTime>{time}</StyledStudyTime>;
+const days_char = ["일", "월", "화", "수", "목", "금", "토"];
+
+const StudyTime = ({ startTime, during, days }) => {
+  const time = `${days
+    .map(dayNumber => days_char[dayNumber])
+    .join(", ")} | ${startTime}:00 시작 | ${during}시간 `;
+  return <StyledStudyTime>{time}</StyledStudyTime>;
+};
 
 export default memo(StudyTime);

--- a/client/src/components/users/groupDetail/Header.jsx
+++ b/client/src/components/users/groupDetail/Header.jsx
@@ -8,9 +8,8 @@ const StyledHeader = styled.div`
   }
 `;
 
-const Header = ({ state }) => {
-  const { groupInfo } = state;
-  const { title, category } = groupInfo;
+const Header = ({ groupData }) => {
+  const { title, category } = groupData;
   const categoryBtnEvent = useCallback(e => {
     const categoryName = e.target.textContent.trim();
     alert(categoryName);
@@ -25,9 +24,14 @@ const Header = ({ state }) => {
             className="button is-primary is-small"
             onClick={categoryBtnEvent}
           >
-            {" "}
-            {category}{" "}
-          </button>{" "}
+            {category[0]}
+          </button>
+          <button
+            className="button is-primary is-small"
+            onClick={categoryBtnEvent}
+          >
+            {category[1]}
+          </button>
         </div>
       </div>
     </StyledHeader>

--- a/client/src/components/users/groupDetail/Main.jsx
+++ b/client/src/components/users/groupDetail/Main.jsx
@@ -1,10 +1,11 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useContext } from "react";
 import styled from "styled-components";
 import classnames from "classnames";
 import Location from "../common/Location";
 import Time from "../groupCard/Time";
 import TagButtons from "../common/TagButtons";
 import { REGISTER } from "../../../reducer/users/groupDetail";
+import { UserContext } from "../../../pages/users/index";
 
 const StyledMain = styled.div`
   width: 100%;
@@ -49,20 +50,26 @@ const StyledMain = styled.div`
   padding: 1.2rem;
 `;
 
-const Main = ({ state, dispatch }) => {
-  const { groupInfo } = state;
+const Main = ({ groupData, dispatch }) => {
+  const { userInfo } = useContext(UserContext);
+  const { userEmail } = userInfo;
   const {
-    studyThumbnail,
+    thumbnail,
     location,
-    time,
+    startTime,
+    days,
+    during,
     tags,
-    minCnt,
-    nowCnt,
-    maxCnt,
-    isMember,
-    isMaster,
-    isRecruiting
-  } = groupInfo;
+    min_personnel,
+    now_personnel,
+    max_personnel,
+    leader,
+    isRecruiting,
+    members
+  } = groupData;
+
+  const isMember = members.some(memberId => memberId === userEmail);
+  const isLeader = leader === userEmail;
 
   const isMemberClass = classnames("button", {
     "is-primary": !isMember,
@@ -71,7 +78,10 @@ const Main = ({ state, dispatch }) => {
   const isMemberText = isMember ? "취소하기" : "신청하기";
 
   const isRecruitingClass = classnames({
-    disable: isRecruiting || nowCnt > maxCnt || nowCnt < minCnt
+    disable:
+      isRecruiting ||
+      now_personnel > max_personnel ||
+      now_personnel < min_personnel
   });
   const isRecruitingText = isRecruiting ? "마감하기" : "모집 재개";
 
@@ -82,31 +92,32 @@ const Main = ({ state, dispatch }) => {
   return (
     <StyledMain className="columns">
       <div className="column imageDiv is-half">
-        <img src={studyThumbnail} alt="img" />
+        <img src={thumbnail} alt="img" />
       </div>
 
       <div className="column content">
         <Location location={location} />
 
         <h4>
-          <Time time={time} />
+          <Time startTime={startTime} during={during} days={days} />
         </h4>
 
-        <p> 최소 인원: {minCnt} </p>
-        <p> 현재 인원: {nowCnt} </p>
-        <p> 최대 인원: {maxCnt} </p>
+        <p> 최소 인원: {min_personnel} </p>
+        <p> 현재 인원: {now_personnel} </p>
+        <p> 최대 인원: {max_personnel} </p>
 
         <TagButtons tags={tags} />
 
         <div className="buttons">
-          {isMaster || (
-            <button className={isMemberClass} onClick={registerEvent}>
-              {" "}
-              {isMemberText}{" "}
-            </button>
-          )}
+          {userEmail &&
+            (isLeader || (
+              <button className={isMemberClass} onClick={registerEvent}>
+                {" "}
+                {isMemberText}{" "}
+              </button>
+            ))}
 
-          {isMaster && isMember && (
+          {isLeader && isMember && (
             <>
               <button className={`button is-danger ${!isRecruitingClass}`}>
                 {isRecruitingText}

--- a/client/src/components/users/groupDetail/Main.jsx
+++ b/client/src/components/users/groupDetail/Main.jsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import Location from "../common/Location";
 import Time from "../groupCard/Time";
 import TagButtons from "../common/TagButtons";
-import { REGISTER } from "../../reducer/users/groupDetail";
+import { REGISTER } from "../../../reducer/users/groupDetail";
 
 const StyledMain = styled.div`
   width: 100%;

--- a/client/src/components/users/myStudyCardCarousel/Card.jsx
+++ b/client/src/components/users/myStudyCardCarousel/Card.jsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+import { UserContext } from "../../../pages/users";
 
 const StyledCard = styled.div`
   width: 16rem;
@@ -43,16 +44,17 @@ const StyledCard = styled.div`
   }
 `;
 
-const StudyGroupCardMini = ({
-  cardData: { leader, img, title, id },
-  user_email
-}) => {
+const StudyGroupCardMini = ({ groupData }) => {
+  const { userInfo } = useContext(UserContext);
+  const { userEmail } = userInfo;
+  const { leader, title, img, id } = groupData;
+
   return (
     <Link to={`/group/detail/${id}`}>
       <StyledCard className={`card study-mini-card`}>
         <div
           className="group-leader-bedge"
-          style={{ display: leader === user_email ? "block" : "none" }}
+          style={{ display: leader === userEmail ? "block" : "none" }}
         >
           그룹장
         </div>

--- a/client/src/components/users/myStudyCardCarousel/index.jsx
+++ b/client/src/components/users/myStudyCardCarousel/index.jsx
@@ -50,15 +50,13 @@ const MyStudyCarousel = () => {
       <div>
         <div className="my-group-title">👨‍👨‍👧‍👦현재 함께하는 그룹이에요</div>
         <div className="carousel">
-          {myGroups.length
-            ? myGroups.map(groupData => {
-                return (
-                  <div className="carousel-item">
-                    <StudyGroupCardMini groupData={groupData} />
-                  </div>
-                );
-              })
-            : "소속된 그룹이 없어요"}
+          {myGroups.map(groupData => {
+            return (
+              <div className="carousel-item">
+                <StudyGroupCardMini groupData={groupData} />
+              </div>
+            );
+          })}
         </div>
       </div>
     </StyledMyStudyCarousel>

--- a/client/src/components/users/myStudyCardCarousel/index.jsx
+++ b/client/src/components/users/myStudyCardCarousel/index.jsx
@@ -4,8 +4,9 @@ import StudyGroupCardMini from "./Card";
 import { UserContext } from "../../../pages/users/index";
 import bulmaCarousel from "bulma-carousel/dist/js/bulma-carousel.min.js";
 
-const Main = styled.div`
-  .carousel-box{
+const StyledMyStudyCarousel = styled.div`
+overflow: hidden;
+width: ${props => props.carouselWidth}; 
     overflow:hidden;
 
     .carousel{
@@ -19,14 +20,14 @@ const Main = styled.div`
     }
 
     .my-group-title{
+      text-align: center;
       font-weight:bold;
-      font-size:1.5em;
+      font-size: 1.3em;
       padding 0 0 3%;
     }
     .slider-page{
       box-shadow:0 2px 5px #323232;
     }
-  }
  
 `;
 
@@ -45,11 +46,8 @@ const MyStudyCarousel = () => {
   });
 
   return (
-    <Main>
-      <div
-        className="carousel-box"
-        style={{ overflow: "hidden", width: carouselWidth }}
-      >
+    <StyledMyStudyCarousel carouselWidth={carouselWidth}>
+      <div>
         <div className="my-group-title">👨‍👨‍👧‍👦현재 함께하는 그룹이에요</div>
         <div className="carousel">
           {myGroups.length
@@ -63,7 +61,7 @@ const MyStudyCarousel = () => {
             : "소속된 그룹이 없어요"}
         </div>
       </div>
-    </Main>
+    </StyledMyStudyCarousel>
   );
 };
 

--- a/client/src/components/users/myStudyCardCarousel/index.jsx
+++ b/client/src/components/users/myStudyCardCarousel/index.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useContext, useCallback } from "react";
 import styled from "styled-components";
 import StudyGroupCardMini from "./Card";
+import { UserContext } from "../../../pages/users/index";
 import bulmaCarousel from "bulma-carousel/dist/js/bulma-carousel.min.js";
 
 const Main = styled.div`
@@ -29,7 +30,11 @@ const Main = styled.div`
  
 `;
 
-const MyStudyCarousel = ({ myGroups, user_email }) => {
+const MyStudyCarousel = () => {
+  const { userIndexState } = useContext(UserContext);
+  const { myGroups } = userIndexState;
+  const carouselWidth = myGroups.length ? myGroups.length * 15 + "em" : "100%";
+
   useEffect(() => {
     if (myGroups.length > 3)
       bulmaCarousel.attach(".carousel", {
@@ -43,17 +48,19 @@ const MyStudyCarousel = ({ myGroups, user_email }) => {
     <Main>
       <div
         className="carousel-box"
-        style={{ overflow: "hidden", width: `${myGroups.length * 15}em` }}
+        style={{ overflow: "hidden", width: carouselWidth }}
       >
         <div className="my-group-title">👨‍👨‍👧‍👦현재 함께하는 그룹이에요</div>
         <div className="carousel">
-          {myGroups.map(group => {
-            return (
-              <div className="carousel-item">
-                <StudyGroupCardMini cardData={group} user_email={user_email} />
-              </div>
-            );
-          })}
+          {myGroups.length
+            ? myGroups.map(groupData => {
+                return (
+                  <div className="carousel-item">
+                    <StudyGroupCardMini groupData={groupData} />
+                  </div>
+                );
+              })
+            : "소속된 그룹이 없어요"}
         </div>
       </div>
     </Main>

--- a/client/src/components/users/studySearchNavbar/StudyNavbarItem.jsx
+++ b/client/src/components/users/studySearchNavbar/StudyNavbarItem.jsx
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { useCallback, useContext } from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
+import axios from "axios";
+import { REQUEST_URL } from "../../../config.json";
+import { UserContext } from "../../../pages/users/index";
+import { set_groups } from "../../../reducer/users/index";
 
 const Category = styled.div`
   a {
@@ -8,19 +11,45 @@ const Category = styled.div`
     font-weight: bold;
     font-size: 1.7em;
   }
+
+  .navbar-item {
+    cursor: pointer;
+  }
 `;
 
 const StudyNavbarItem = ({ primaryCategory, secondaryCategories }) => {
+  const { userIndexDispatch } = useContext(UserContext);
+
+  const searchGroups = useCallback(e => {
+    const categoryName = e.target.textContent.trim();
+
+    axios.get(`${REQUEST_URL}/search/all/${categoryName}/true`).then(result => {
+      const { data } = result;
+
+      for (let i = 0; i < data.length; i++) {
+        data[i].id = i;
+        data[
+          i
+        ].location = `위도: ${data[i].location.lat}, 경도: ${data[i].location.lon}`;
+      }
+
+      userIndexDispatch(set_groups(data));
+    });
+  }, []);
+
   const itemList = secondaryCategories.map(category => (
-    <Link className="navbar-item" to={`/category/${category}`}>
+    <span className="navbar-item is-size-3" onClick={searchGroups}>
       {category}
-    </Link>
+    </span>
   ));
 
   return (
     <Category>
       <div className="navbar-item has-dropdown is-hoverable">
-        <span className="navbar-link is-arrowless is-size-3">
+        <span
+          className="navbar-link is-arrowless is-size-3"
+          onClick={searchGroups}
+        >
           {primaryCategory}
         </span>
         <div className="navbar-dropdown is-boxed">{itemList}</div>

--- a/client/src/components/users/studySearchNavbar/StudyNavbarItem.jsx
+++ b/client/src/components/users/studySearchNavbar/StudyNavbarItem.jsx
@@ -37,8 +37,8 @@ const StudyNavbarItem = ({ primaryCategory, secondaryCategories }) => {
     });
   }, []);
 
-  const itemList = secondaryCategories.map(category => (
-    <span className="navbar-item is-size-3" onClick={searchGroups}>
+  const itemList = secondaryCategories.map((category, idx) => (
+    <span key={idx} className="navbar-item is-size-3" onClick={searchGroups}>
       {category}
     </span>
   ));

--- a/client/src/components/users/studySearchNavbar/index.jsx
+++ b/client/src/components/users/studySearchNavbar/index.jsx
@@ -1,8 +1,11 @@
-import React, { useContext } from "react";
+import React, { useContext, useCallback } from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
+import axios from "axios";
+
+import { REQUEST_URL } from "../../../config.json";
 import StudyNavbarItem from "./StudyNavbarItem";
 import { UserContext } from "../../../pages/users/index";
+import { set_groups } from "../../../reducer/users/index";
 
 const Navbar = styled.div`
   padding: 5%;
@@ -18,11 +21,30 @@ const Navbar = styled.div`
     font-weight: bold;
     font-size: 1.7em;
   }
+
+  .navbar-item {
+    cursor: pointer;
+  }
 `;
 
 const StudySearchNavbar = () => {
-  const { userIndexState } = useContext(UserContext);
+  const { userIndexState, userIndexDispatch } = useContext(UserContext);
   const { primaryCategories, secondaryCategories } = userIndexState;
+
+  const searchAllGroups = useCallback(() => {
+    axios.get(`${REQUEST_URL}/search/all/true`).then(result => {
+      const { data } = result;
+
+      for (let i = 0; i < data.length; i++) {
+        data[i].id = i;
+        data[
+          i
+        ].location = `위도: ${data[i].location.lat}, 경도: ${data[i].location.lon}`;
+      }
+
+      userIndexDispatch(set_groups(data));
+    });
+  }, []);
 
   return (
     <Navbar>
@@ -33,9 +55,9 @@ const StudySearchNavbar = () => {
       >
         <div id="navbarExampleTransparentExample" style={{ width: "100%" }}>
           <div className="navbar-start">
-            <Link className="navbar-item" to="/">
+            <span className="navbar-item is-size-3" onClick={searchAllGroups}>
               모두 보기
-            </Link>
+            </span>
 
             {primaryCategories.map(category => (
               <StudyNavbarItem

--- a/client/src/components/users/studySearchNavbar/index.jsx
+++ b/client/src/components/users/studySearchNavbar/index.jsx
@@ -8,7 +8,6 @@ import { UserContext } from "../../../pages/users/index";
 import { set_groups } from "../../../reducer/users/index";
 
 const Navbar = styled.div`
-  padding: 5%;
   width: 100%;
   .navbar-start {
     display: flex;

--- a/client/src/components/users/studySearchNavbar/index.jsx
+++ b/client/src/components/users/studySearchNavbar/index.jsx
@@ -58,8 +58,9 @@ const StudySearchNavbar = () => {
               모두 보기
             </span>
 
-            {primaryCategories.map(category => (
+            {primaryCategories.map((category, idx) => (
               <StudyNavbarItem
+                key={idx}
                 primaryCategory={category}
                 secondaryCategories={secondaryCategories[category]}
               ></StudyNavbarItem>

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext } from "react";
 import styled from "styled-components";
 import axios from "axios";
-import { Link, BrowserRouter as Router } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import { REQUEST_URL } from "../../config.json";
 
@@ -113,20 +113,18 @@ const MainPage = () => {
         )}
       </div>
 
-      <Router>
-        <div className="study-group-list">
-          {searchList.length
-            ? searchList.map(groupData => {
-                return (
-                  <StudyGroupCard
-                    key={groupData.id}
-                    groupData={groupData}
-                  ></StudyGroupCard>
-                );
-              })
-            : "데이터가 업소용"}
-        </div>
-      </Router>
+      <div className="study-group-list">
+        {searchList.length
+          ? searchList.map(groupData => {
+              return (
+                <StudyGroupCard
+                  key={groupData.id}
+                  groupData={groupData}
+                ></StudyGroupCard>
+              );
+            })
+          : "데이터가 업소용"}
+      </div>
     </Main>
   );
 };

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -76,7 +76,7 @@ const MainPage = () => {
   const { userIndexState, userIndexDispatch, userInfo } = useContext(
     UserContext
   );
-  const { searchList } = userIndexState;
+  const { searchList, myGroups } = userIndexState;
   const { userEmail } = userInfo;
 
   useEffect(() => {
@@ -96,7 +96,11 @@ const MainPage = () => {
       <div className="main-jumbotron">
         {userEmail ? (
           <>
-            <MyStudyCarousel></MyStudyCarousel>
+            {myGroups.length ? (
+              <MyStudyCarousel></MyStudyCarousel>
+            ) : (
+              "현재 소속된 스터디 그룹이 없습니다."
+            )}
             <Link to="/group/create" className="group-create-button">
               {" "}
               <button className="button"> 그룹 생성 </button>

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -85,9 +85,6 @@ const MainPage = () => {
 
       for (let i = 0; i < data.length; i++) {
         data[i].id = i;
-        data[
-          i
-        ].location = `위도: ${data[i].location.lat}, 경도: ${data[i].location.lon}`;
       }
 
       userIndexDispatch(set_groups(data));

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -117,7 +117,12 @@ const MainPage = () => {
         <div className="study-group-list">
           {searchList.length
             ? searchList.map(groupData => {
-                return <StudyGroupCard groupData={groupData}></StudyGroupCard>;
+                return (
+                  <StudyGroupCard
+                    key={groupData.id}
+                    groupData={groupData}
+                  ></StudyGroupCard>
+                );
               })
             : "데이터가 업소용"}
         </div>

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -5,7 +5,6 @@ import { Link, BrowserRouter as Router } from "react-router-dom";
 
 import { REQUEST_URL } from "../../config.json";
 
-import StudySearchNavbar from "../../components/users/studySearchNavbar";
 import StudyGroupCard from "../../components/users/groupCard";
 import MyStudyCarousel from "../../components/users/myStudyCardCarousel";
 
@@ -92,7 +91,7 @@ const MainPage = () => {
       }
 
       userIndexDispatch(set_groups(data));
-    }, []);
+    });
   }, []);
 
   return (
@@ -118,8 +117,6 @@ const MainPage = () => {
       </div>
 
       <Router>
-        <StudySearchNavbar></StudySearchNavbar>
-
         <div className="study-group-list">
           {searchList.length
             ? searchList.map(groupData => {

--- a/client/src/pages/users/groupDetail.jsx
+++ b/client/src/pages/users/groupDetail.jsx
@@ -17,12 +17,12 @@ const StyledGroupDetail = styled.div`
 `;
 
 const GroupDetail = () => {
-  const [state, dispatch] = useReducer(groupDetailReducer, initialState);
+  const [groupData, dispatch] = useReducer(groupDetailReducer, initialState);
 
   return (
     <StyledGroupDetail>
-      <Header state={state}></Header>
-      <Main state={state} dispatch={dispatch}></Main>
+      <Header groupData={groupData}></Header>
+      <Main groupData={groupData} dispatch={dispatch}></Main>
       <Intro></Intro>
     </StyledGroupDetail>
   );

--- a/client/src/pages/users/index.jsx
+++ b/client/src/pages/users/index.jsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { Route, Switch } from "react-router-dom";
 
 import MainPage from "./Main";
+import GroupDetailPage from "./groupDetail";
 import GroupCreatePage from "./groupCreate";
 import Header from "../../components/users/Header";
 import { initalState, userIndexReducer } from "../../reducer/users";
@@ -33,7 +34,8 @@ const UserPage = () => {
         <Header />
         <Switch>
           <Route exact path="/" component={MainPage} />
-          <Route path="/group/create" component={GroupCreatePage} />
+          <Route exact path="/group/create" component={GroupCreatePage} />
+          <Route path="/group/detail/:id" component={GroupDetailPage} />
         </Switch>
       </StyledUserPage>
     </UserContext.Provider>

--- a/client/src/reducer/users/groupDetail.jsx
+++ b/client/src/reducer/users/groupDetail.jsx
@@ -3,21 +3,21 @@ export const REGISTER = "groupDetail/REGISTER";
 export const register = () => ({ type: REGISTER });
 
 export const initialState = {
-  groupInfo: {
-    title: "자바스크립트 기초 공부해요",
-    category: "프로그래밍",
-    studyThumbnail:
-      "https://secure.meetupstatic.com/photos/event/c/6/d/c/600_482150908.jpeg",
-    location: "서울시 서초구 서초1동",
-    time: "월,수 | 20:00~ | 2시간",
-    minCnt: 1,
-    nowCnt: 2,
-    maxCnt: 4,
-    tags: ["Java", "C++", "Python"],
-    isMaster: false,
-    isMember: false,
-    isRecruiting: true
-  }
+  title: "자바스크립트 기초 공부해요",
+  subtitle: "자바스크립트 기초없이 할려고 했어?",
+  category: ["프로그래밍", "JavaScript"],
+  thumbnail:
+    "https://secure.meetupstatic.com/photos/event/c/6/d/c/600_482150908.jpeg",
+  location: { lat: 50, lon: 40 },
+  startTime: 5,
+  days: [1, 3],
+  during: 2,
+  min_personnel: 1,
+  now_personnel: 2,
+  max_personnel: 4,
+  tags: ["Java", "C++", "Python"],
+  leader: "dlatns0201@naver.com",
+  members: []
 };
 
 export const groupDetail = (state, action) => {

--- a/client/src/reducer/users/index.jsx
+++ b/client/src/reducer/users/index.jsx
@@ -8,20 +8,20 @@ export const set_groups = searchList => ({
 export const initalState = {
   myGroups: [],
   searchList: [
-    {
-      id: 0,
-      days: [],
-      startTime: 0,
-      during: 0,
-      location: { lat: 0, lon: 0 },
-      max_personnel: 0,
-      now_personnel: 0,
-      // min_personnel: 0,
-      title: "",
-      subtitle: "",
-      thumbnail: "",
-      tags: []
-    }
+    // {
+    //   id: 0,
+    //   days: [],
+    //   startTime: 0,
+    //   during: 0,
+    //   //location: { lat: 0, lon: 0 },
+    //   max_personnel: 0,
+    //   now_personnel: 0,
+    //   // min_personnel: 0,
+    //   title: "",
+    //   subtitle: "",
+    //   thumbnail: "",
+    //   tags: []
+    // }
   ],
   primaryCategories: ["프로그래밍", "자격증", "외국어", "면접"],
   secondaryCategories: {

--- a/client/src/reducer/users/index.jsx
+++ b/client/src/reducer/users/index.jsx
@@ -6,7 +6,14 @@ export const set_groups = searchList => ({
 });
 
 export const initalState = {
-  myGroups: [],
+  myGroups: [
+    // {
+    //   id: "",
+    //   img: "",
+    //   title: "",
+    //   leader: ""
+    // }
+  ],
   searchList: [
     // {
     //   id: 0,

--- a/client/src/reducer/users/index.jsx
+++ b/client/src/reducer/users/index.jsx
@@ -7,7 +7,22 @@ export const set_groups = searchList => ({
 
 export const initalState = {
   myGroups: [],
-  searchList: [],
+  searchList: [
+    {
+      id: 0,
+      days: [],
+      startTime: 0,
+      during: 0,
+      location: { lat: 0, lon: 0 },
+      max_personnel: 0,
+      now_personnel: 0,
+      // min_personnel: 0,
+      title: "",
+      subtitle: "",
+      thumbnail: "",
+      tags: []
+    }
+  ],
   primaryCategories: ["프로그래밍", "자격증", "외국어", "면접"],
   secondaryCategories: {
     프로그래밍: ["C++", "Java", "JavaScript"],


### PR DESCRIPTION
# 구현 내용
- 모두 보기 및 카테고리 버튼 서버 요청으로 변경
- 카테고리를 헤더로 위치시킴
- 탐색하는 카드들에 태그 표시
- reducer/index에 초기 상태 속성 주석으로 명세함
- location 상태를 서버에서 받는 규격에 맞게 lat, lon 속성을 가진 객체 형식으로 갱신
- MyCard들에 대해서 리팩토링한 구조에 맞게 상태를 뷰에 지정
