### PR TITLE
사용자 로그인 컴포넌트 리팩토링

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,13 +9,15 @@
     "axios": "^0.19.0",
     "bulma-carousel": "^4.0.4",
     "classnames": "^2.2.6",
+    "eslint-plugin-import": "^2.18.2",
     "husky": "^1.3.1",
     "js-cookie": "^2.2.1",
     "jwt-decode": "^2.2.0",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
+    "react-kakao-login": "^1.2.0",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.2.0",
+    "react-scripts": "^3.2.0",
     "styled-components": "^4.4.1"
   },
   "scripts": {

--- a/client/src/components/users/Header.jsx
+++ b/client/src/components/users/Header.jsx
@@ -109,11 +109,6 @@ const Header = () => {
             onKeyUp={onKeyUp}
           />
         </div>
-        <div className={`account-box`}>
-          <div className={`user-account-btn accountbox-btn`}>
-            <span> {userName}님 환영합니다. </span>
-          </div>
-        </div>
         <UserInfo />
       </div>
       <StudySearchNavbar />

--- a/client/src/components/users/UserInfo/LoginButton.jsx
+++ b/client/src/components/users/UserInfo/LoginButton.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useCallback } from "react";
 import styled from "styled-components";
 import KakaoLogin from "react-kakao-login";
 import axios from "axios";
@@ -15,51 +15,51 @@ const KakaoLoginButton = styled(KakaoLogin)`
   }
 `;
 
-const userInfoParser = ({ profile, response }) => {
-  const { kakao_account, properties } = profile;
-
-  return {
-    userAgeRange: +kakao_account.age_range[0],
-    userName: properties.nickname,
-    userEmail: kakao_account.email,
-    userGender: kakao_account.gender,
-    profileImage: properties.profile_image,
-    accessToken: response.access_token
-  };
-};
-
 const LoginButton = () => {
   const { userInfo, setUserInfo } = useContext(UserContext);
+
+  const userInfoParser = useCallback(({ profile, response }) => {
+    const { kakao_account, properties } = profile;
+
+    return {
+      userAgeRange: +kakao_account.age_range[0],
+      userName: properties.nickname,
+      userEmail: kakao_account.email,
+      userGender: kakao_account.gender,
+      profileImage: properties.profile_image,
+      accessToken: response.access_token
+    };
+  }, []);
+
+  const onSuccess = ({ response, profile }) => {
+    const email = profile.kakao_account.email;
+
+    // axios
+    //   .post(`${REQUEST_URL}/auth/users/checkEmail`, { email })
+    //   .then(({ data }) => {
+    //     if (!data.exist) {
+    //       // 처음 방문한 사용자라면 위치를 입력받아서 데이터베이스에 저장
+    //       const location = prompt(
+    //         "처음이신가봐요! 거주하고 계신 동네를 말씀해 주세요"
+    //       );
+    //     }
+    //     const tmp = Object.assign(
+    //       userInfo,
+    //       userInfoParser({ response, profile })
+    //     );
+    //     setUserInfo(tmp);
+    //   })
+    //   .catch(e => {
+    //     console.error(e);
+    //   });
+    setUserInfo({ ...userInfo, ...userInfoParser({ response, profile }) });
+  };
 
   return (
     <KakaoLoginButton
       className="button is-warning is-rounded"
       jsKey={KAKAO_JS_KEY}
-      onSuccess={({ response, profile }) => {
-        const email = profile.kakao_account.email;
-
-        // axios
-        //   .post(`${REQUEST_URL}/auth/users/checkEmail`, { email })
-        //   .then(({ data }) => {
-        //     if (!data.exist) {
-        //       // 처음 방문한 사용자라면 위치를 입력받아서 데이터베이스에 저장
-        //       const location = prompt(
-        //         "처음이신가봐요! 거주하고 계신 동네를 말씀해 주세요"
-        //       );
-        //     }
-        //     const tmp = Object.assign(
-        //       userInfo,
-        //       userInfoParser({ response, profile })
-        //     );
-        //     setUserInfo(tmp);
-        //   })
-        //   .catch(e => {
-        //     console.error(e);
-        //   });
-        setUserInfo(
-          Object.assign(userInfo, userInfoParser({ response, profile }))
-        );
-      }}
+      onSuccess={onSuccess}
       onFailure={res => {
         // Caution popup
         console.error(res);

--- a/client/src/components/users/UserInfo/LoginButton.jsx
+++ b/client/src/components/users/UserInfo/LoginButton.jsx
@@ -38,24 +38,27 @@ const LoginButton = () => {
       onSuccess={({ response, profile }) => {
         const email = profile.kakao_account.email;
 
-        axios
-          .post(`${REQUEST_URL}/auth/users/checkEmail`, { email })
-          .then(({ data }) => {
-            if (!data.exist) {
-              // 처음 방문한 사용자라면 위치를 입력받아서 데이터베이스에 저장
-              const location = prompt(
-                "처음이신가봐요! 거주하고 계신 동네를 말씀해 주세요"
-              );
-            }
-            const tmp = Object.assign(
-              userInfo,
-              userInfoParser({ response, profile })
-            );
-            setUserInfo(tmp);
-          })
-          .catch(e => {
-            console.error(e);
-          });
+        // axios
+        //   .post(`${REQUEST_URL}/auth/users/checkEmail`, { email })
+        //   .then(({ data }) => {
+        //     if (!data.exist) {
+        //       // 처음 방문한 사용자라면 위치를 입력받아서 데이터베이스에 저장
+        //       const location = prompt(
+        //         "처음이신가봐요! 거주하고 계신 동네를 말씀해 주세요"
+        //       );
+        //     }
+        //     const tmp = Object.assign(
+        //       userInfo,
+        //       userInfoParser({ response, profile })
+        //     );
+        //     setUserInfo(tmp);
+        //   })
+        //   .catch(e => {
+        //     console.error(e);
+        //   });
+        setUserInfo(
+          Object.assign(userInfo, userInfoParser({ response, profile }))
+        );
       }}
       onFailure={res => {
         // Caution popup

--- a/client/src/components/users/UserInfo/LoginButton.jsx
+++ b/client/src/components/users/UserInfo/LoginButton.jsx
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useContext } from "react";
 import styled from "styled-components";
-import { REQUEST_URL } from "../../../config.json";
+import KakaoLogin from "react-kakao-login";
+import axios from "axios";
+import { UserContext } from "../../../pages/users";
+import { REQUEST_URL, KAKAO_JS_KEY } from "../../../config.json";
 
-const Button = styled.button`
+const KakaoLoginButton = styled(KakaoLogin)`
   img {
     height: 24px;
     width: 24px;
@@ -12,17 +15,57 @@ const Button = styled.button`
   }
 `;
 
+const userInfoParser = ({ profile, response }) => {
+  const { kakao_account, properties } = profile;
+
+  return {
+    userAgeRange: +kakao_account.age_range[0],
+    userName: properties.nickname,
+    userEmail: kakao_account.email,
+    userGender: kakao_account.gender,
+    profileImage: properties.profile_image,
+    accessToken: response.access_token
+  };
+};
+
 const LoginButton = () => {
+  const { userInfo, setUserInfo } = useContext(UserContext);
+
   return (
-    <Button
+    <KakaoLoginButton
       className="button is-warning is-rounded"
-      onClick={() => {
-        window.location.href = `${REQUEST_URL}/auth/users/login`;
+      jsKey={KAKAO_JS_KEY}
+      onSuccess={({ response, profile }) => {
+        const email = profile.kakao_account.email;
+
+        axios
+          .post(`${REQUEST_URL}/auth/users/checkEmail`, { email })
+          .then(({ data }) => {
+            if (!data.exist) {
+              // 처음 방문한 사용자라면 위치를 입력받아서 데이터베이스에 저장
+              const location = prompt(
+                "처음이신가봐요! 거주하고 계신 동네를 말씀해 주세요"
+              );
+            }
+            const tmp = Object.assign(
+              userInfo,
+              userInfoParser({ response, profile })
+            );
+            setUserInfo(tmp);
+          })
+          .catch(e => {
+            console.error(e);
+          });
       }}
+      onFailure={res => {
+        // Caution popup
+        console.error(res);
+      }}
+      getProfile="true"
     >
       <img src="/image/kakao-talk.png" alt="kakao-talk" />
       <span>&nbsp; 카카오톡으로 로그인하기</span>
-    </Button>
+    </KakaoLoginButton>
   );
 };
 

--- a/client/src/components/users/UserInfo/index.jsx
+++ b/client/src/components/users/UserInfo/index.jsx
@@ -4,13 +4,22 @@ import LoginButton from "./LoginButton";
 import LogoutButton from "./LogoutButton";
 
 const UserInfo = () => {
-  const { userEmail, profileImage, userName } = useContext(UserContext);
+  const { userInfo } = useContext(UserContext);
+
   return (
     <div>
-      {userEmail ? (
+      {userInfo.userEmail ? (
         <>
-          <img src={profileImage} alt="profile" />
-          <span>{userName}님 반갑습니다.</span>
+          <img
+            src={userInfo.profileImage}
+            alt="profile"
+            style={{
+              borderRadius: "50%",
+              height: "2.5rem",
+              marginRight: "1rem"
+            }}
+          />
+          {/* <span>{userInfo.userName}님 반갑습니다.</span> */}
           <LogoutButton />
         </>
       ) : (

--- a/client/src/config.json
+++ b/client/src/config.json
@@ -1,3 +1,4 @@
 {
-  "REQUEST_URL": "http://106.10.41.25:8000"
+  "REQUEST_URL": "http://106.10.41.25:8000",
+  "KAKAO_JS_KEY": "c49eed0d6a5ff7d17da77345591620cb"
 }

--- a/client/src/pages/users/index.jsx
+++ b/client/src/pages/users/index.jsx
@@ -27,6 +27,7 @@ const getCurrentPosition = new Promise((resolve, reject) => {
 
 const UserPage = () => {
   const [userInfo, setUserInfo] = useState({
+    accessToken: "",
     userEmail: "",
     userName: "",
     userAgeRange: -1,
@@ -56,7 +57,7 @@ const UserPage = () => {
 
   return (
     <UserContext.Provider
-      value={{ userInfo, userIndexState, userIndexDispatch }}
+      value={{ userInfo, setUserInfo, userIndexState, userIndexDispatch }}
     >
       <StyledUserPage>
         <Header />

--- a/server/api-gateway/README.md
+++ b/server/api-gateway/README.md
@@ -1,5 +1,31 @@
 # API Gateway
 
+API 게이트웨이는 클라이언트의 요청을 제일 먼저 받는 서버입니다. 클라이언트에게서 온 요청을 어느 서비스에게 줄 것인지 확인하기도 하며 인증작업도 하고 있습니다.
+
+## API
+
+### 1. 사용자 등록 유무 확인
+
+사용자가 처음 방문했는 지 확인하기 위한 요청입니다. 사용자의 이메일이 데이터베이스에 존재하지 않는다면 `false`를 반환하고 추가적인 작업을 합니다.
+
+- `POST /auth/users/checkEmail`
+- Params
+
+```json
+{
+  "email": String
+}
+```
+
+- Res
+
+```json
+{	"exist": true }
+////// or ///////
+{ "exist": false }
+
+```
+
 ## Database Schema
 
 ### Partners-account


### PR DESCRIPTION
# 구현 내용
- 원래의 방식은 패스포트를 사용한 방법이었지만 클라이언트 단에서 카카오 javascript api 사용으로 변경.
- access_token 및 사용자 정보를 받아오는 npm 모듈을 사용. (`react-kakao-login`)
- 로그인을 성공하면
  1. 사용자 데이터베이스에 접근하여 기존 멤버인지 확인
  2. 신규 사용자라면 위치를 입력 받음
  3. 입력 받은 위치를 데이터베이스에 저장
  4. set state
