### PR TITLE
그룹 상세 페이지 뷰

### DIFF
--- a/client/src/components/users/groupCard/Footer.jsx
+++ b/client/src/components/users/groupCard/Footer.jsx
@@ -14,7 +14,7 @@ const Footer = ({
   footerData: {
     location,
     startTime,
-    during,
+    endTime,
     days,
     now_personnel,
     max_personnel,
@@ -25,7 +25,7 @@ const Footer = ({
     <StyledFooter>
       <TagButtons tags={tags} />
       <Location location={location} />
-      <TimeInfo days={days} startTime={startTime} during={during} />
+      <TimeInfo days={days} startTime={startTime} endTime={endTime} />
       <Personnel now_personnel={now_personnel} max_personnel={max_personnel} />
     </StyledFooter>
   );

--- a/client/src/components/users/groupCard/Time.jsx
+++ b/client/src/components/users/groupCard/Time.jsx
@@ -7,10 +7,11 @@ const StyledStudyTime = styled.div`
 
 const days_char = ["일", "월", "화", "수", "목", "금", "토"];
 
-const StudyTime = ({ startTime, during, days }) => {
-  const time = `${days
-    .map(dayNumber => days_char[dayNumber])
-    .join(", ")} | ${startTime}:00 시작 | ${during}시간 `;
+const StudyTime = ({ startTime, endTime, days }) => {
+  const time = `${days &&
+    days
+      .map(dayNumber => days_char[dayNumber])
+      .join(", ")} | ${startTime}:00 시작 | ${endTime}시간 `;
   return <StyledStudyTime>{time}</StyledStudyTime>;
 };
 

--- a/client/src/components/users/groupDetail/Intro.jsx
+++ b/client/src/components/users/groupDetail/Intro.jsx
@@ -19,11 +19,11 @@ const StyledIntro = styled.div`
   }
 `;
 
-const Intro = () => {
+const Intro = ({ intro }) => {
   return (
     <StyledIntro>
       <h3> 스터디 소개 </h3>
-      <div className="description">블라블라...</div>
+      <div className="description">{intro}</div>
     </StyledIntro>
   );
 };

--- a/client/src/components/users/groupDetail/Main.jsx
+++ b/client/src/components/users/groupDetail/Main.jsx
@@ -58,7 +58,7 @@ const Main = ({ groupData, dispatch }) => {
     location,
     startTime,
     days,
-    during,
+    endTime,
     tags,
     min_personnel,
     now_personnel,
@@ -68,24 +68,24 @@ const Main = ({ groupData, dispatch }) => {
     members
   } = groupData;
 
-  const isMember = members.some(memberId => memberId === userEmail);
-  const isLeader = leader === userEmail;
+  // const isMember = members.some(memberId => memberId === userEmail);
+  // const isLeader = leader === userEmail;
 
-  const isMemberClass = classnames("button", {
-    "is-primary": !isMember,
-    "is-success": isMember
-  });
-  const isMemberText = isMember ? "취소하기" : "신청하기";
+  // const isMemberClass = classnames("button", {
+  //   "is-primary": !isMember,
+  //   "is-success": isMember
+  // });
+  // const isMemberText = isMember ? "취소하기" : "신청하기";
 
-  const isRecruitingClass = classnames({
-    disable:
-      isRecruiting ||
-      now_personnel > max_personnel ||
-      now_personnel < min_personnel
-  });
-  const isRecruitingText = isRecruiting ? "마감하기" : "모집 재개";
+  // const isRecruitingClass = classnames({
+  //   disable:
+  //     isRecruiting ||
+  //     now_personnel > max_personnel ||
+  //     now_personnel < min_personnel
+  // });
+  // const isRecruitingText = isRecruiting ? "마감하기" : "모집 재개";
 
-  const registerEvent = useCallback(() => {}, [dispatch]);
+  // const registerEvent = useCallback(() => {}, [dispatch]);
 
   return (
     <StyledMain className="columns">
@@ -97,7 +97,7 @@ const Main = ({ groupData, dispatch }) => {
         <Location location={location} />
 
         <h4>
-          <Time startTime={startTime} during={during} days={days} />
+          <Time startTime={startTime} endTime={endTime} days={days} />
         </h4>
 
         <p> 최소 인원: {min_personnel} </p>
@@ -106,7 +106,7 @@ const Main = ({ groupData, dispatch }) => {
 
         <TagButtons tags={tags} />
 
-        <div className="buttons">
+        {/* <div className="buttons">
           {userEmail &&
             (isLeader || (
               <button className={isMemberClass} onClick={registerEvent}>
@@ -127,7 +127,7 @@ const Main = ({ groupData, dispatch }) => {
               </button>
             </>
           )}
-        </div>
+        </div> */}
       </div>
     </StyledMain>
   );

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -87,10 +87,6 @@ const MainPage = () => {
       .get(`${REQUEST_URL}/api/search/all/location/${lat}/${lon}/true`)
       .then(result => {
         const { data } = result;
-
-        for (let i = 0; i < data.length; i++) {
-          data[i].id = i;
-        }
         userIndexDispatch(set_groups(data));
       }, []);
   }, [userLocation]);

--- a/client/src/pages/users/groupCreate.jsx
+++ b/client/src/pages/users/groupCreate.jsx
@@ -76,6 +76,9 @@ const GroupCreate = () => {
 
       data.leader = userEmail;
       data.location = { lat: 41.12, lon: -50.34 };
+      data.endTime = data.startTime + data.during;
+      delete data.during;
+
       form.append("image", data.thumbnail);
       delete data.thumbnail;
       form.append("data", JSON.stringify(data));

--- a/client/src/pages/users/groupDetail.jsx
+++ b/client/src/pages/users/groupDetail.jsx
@@ -19,24 +19,28 @@ const StyledGroupDetail = styled.div`
   margin: 3rem auto;
 `;
 
-const GroupDetail = props => {
+const GroupDetail = ({ match }) => {
   const [groupData, dispatch] = useReducer(groupDetailReducer, initialState);
-  const groupId = props._id;
+  const { id } = match.params;
 
   useEffect(() => {
-    axios
-      .get(`${REQUEST_URL}/api/studygroup/detail/${groupId}`)
-      .then(result => {
-        const groupData = result.data;
-        dispatch(set_detail_data(groupData));
-      });
+    axios.get(`${REQUEST_URL}/api/studygroup/detail/${id}`).then(result => {
+      const groupData = result.data;
+      dispatch(set_detail_data(groupData));
+    });
   }, []);
 
+  const isHaveGroupData = Object.keys(groupData).length;
+  const { intro } = groupData;
   return (
     <StyledGroupDetail>
-      <Header groupData={groupData}></Header>
-      <Main groupData={groupData} dispatch={dispatch}></Main>
-      <Intro></Intro>
+      {isHaveGroupData && (
+        <>
+          <Header groupData={groupData}></Header>
+          <Main groupData={groupData} dispatch={dispatch}></Main>
+          <Intro intro={intro}></Intro>
+        </>
+      )}
     </StyledGroupDetail>
   );
 };

--- a/client/src/reducer/users/groupCreate.jsx
+++ b/client/src/reducer/users/groupCreate.jsx
@@ -65,13 +65,14 @@ export const initialState = {
   },
   daysInfo,
   data: {
+    id: 0,
     category: [null, null],
     leader: "",
     tags: [],
     title: "",
     subtitle: "",
     intro: "",
-    selectedDays: [],
+    days: [],
     startTime: 1,
     during: 1,
     isRecruiting: true,
@@ -116,10 +117,9 @@ export const groupCreateReducer = (state, action) => {
         })
       };
 
-      if (isSelected)
-        data.selectedDays = data.selectedDays.filter(day => day !== idx);
-      else data.selectedDays.push(idx);
-      return { ...state, daysInfo: daysInfo, data };
+      if (isSelected) data.days = data.days.filter(day => day !== idx);
+      else data.days.push(idx);
+      return { ...state, daysInfo, data };
 
     case CHANGE_HOUR:
       const { timeType, hour } = action;


### PR DESCRIPTION
# 구현 내용
- 스터디 그룹 서비스 디비와 연동
-  object id값과 함께 요청한 후 필요한 그룹 정보를 응답 받음
-  응답 받은 데이터를 기반으로 뷰 렌더링
- selectedDays 누락 픽스 -> days로 바꿈
- mount되었을 때 데이터가 없어서 오류가 나는 것의 예외 처리
- 상세 페이지내에서 상태에 따라 버튼 렌더링하는 것, 버튼으로 상태를 수정하는 것은 아직 하지 못함
