### PR TITLE
그룹 서비스 - 상세 페이지

### DIFF
--- a/server/api-gateway/routes/api/studyGroup/ctrl.js
+++ b/server/api-gateway/routes/api/studyGroup/ctrl.js
@@ -9,8 +9,6 @@ exports.uploadToImage = (storage, path, bucketName, bucketLink) => async (
   const imageSrc = `${path}/${Date.now()}${image.originalname}`;
   const imageLink = bucketLink + imageSrc;
 
-  console.log(bucketName);
-
   try {
     await storage
       .putObject({
@@ -29,7 +27,6 @@ exports.uploadToImage = (storage, path, bucketName, bucketLink) => async (
       .promise();
 
     req.imageLink = imageLink;
-    console.log("good\n\n\n\n\n\n");
     next();
   } catch (e) {
     console.error(e);

--- a/server/services/search/elasticsearch.js
+++ b/server/services/search/elasticsearch.js
@@ -392,13 +392,13 @@ exports.searchAllStudyGroupWithCategory = async info => {
 exports.bulkStudyGroups = async groups => {
   if (!Array.isArray(groups)) groups = [groups];
   const body = groups.flatMap(group => {
-    const _id = group.id;
+    const groupObj = JSON.parse(group);
+    const _id = groupObj._id;
 
-    delete group._id;
-    delete group.id;
+    delete groupObj._id;
     return [
       { index: { _index: SEARCH_INDEX_STUDYGROUP, _type: "_doc", _id } },
-      group
+      groupObj
     ];
   });
 

--- a/server/services/studygroup/StudyGroup.js
+++ b/server/services/studygroup/StudyGroup.js
@@ -15,8 +15,8 @@ class StudyGroup extends App {
         try {
           const groupInfo = params.payload;
 
-          await StudyGroups.create(groupInfo);
-          await pushStudyGroups(groupInfo);
+          const result = await StudyGroups.create(groupInfo);
+          await pushStudyGroups(result);
 
           replyData.method = "REPLY";
           replyData.body = { href: "/" };

--- a/server/services/studygroup/StudyGroup.js
+++ b/server/services/studygroup/StudyGroup.js
@@ -29,8 +29,8 @@ class StudyGroup extends App {
 
       case "getGroupDetail":
         try {
-          const { id: _id } = params;
-          const result = await StudyGroups.findOne({ _id });
+          const { id } = params;
+          const result = await StudyGroups.findById(id);
 
           replyData.method = "REPLY";
           replyData.body = result;


### PR DESCRIPTION
# 구현 내용
- 상세 페이지와 엘라스틱 서비스와 동기화를 하기 위해 DB에 저장한 내용을 모듈을 통해 전달
- 엘라스틱 서비스 내에서 stringify한 객체를 parse하지 않아 생긴 오류 픽스
- findOne에서 findById로 변경해 연산 속도 증가
- 불 필요한 console.log 제거
