### PR TITLE
스터디룸 예약 페이지 생성

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -32,6 +32,13 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bulma-carousel@4.0.4/dist/css/bulma-carousel.min.css"
     />
+
+    <!-- 카카오 지도-->
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=be6cd04045a1b2865cf8888359ed0040"
+    ></script>
+
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/client/src/pages/users/index.jsx
+++ b/client/src/pages/users/index.jsx
@@ -9,6 +9,7 @@ import GroupDetailPage from "./groupDetail";
 import GroupCreatePage from "./groupCreate";
 import Header from "../../components/users/Header";
 import { initalState, userIndexReducer } from "../../reducer/users";
+import Reservation from "./reservation";
 
 const StyledUserPage = styled.div``;
 
@@ -65,6 +66,7 @@ const UserPage = () => {
           <Route exact path="/" component={MainPage} />
           <Route exact path="/group/create" component={GroupCreatePage} />
           <Route path="/group/detail/:id" component={GroupDetailPage} />
+          <Route path="/reservation" component={Reservation} />
         </Switch>
       </StyledUserPage>
     </UserContext.Provider>

--- a/client/src/pages/users/reservation.jsx
+++ b/client/src/pages/users/reservation.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+
+const StyledGroupCreate = styled.div``;
+
+const Reservation = () => {
+  const { kakao } = window;
+  useEffect(() => {
+    let el = document.querySelector("#map");
+    var options = {
+      //지도를 생성할 때 필요한 기본 옵션
+      center: new kakao.maps.LatLng(33.450701, 126.570667), //지도의 중심좌표.
+      level: 3 //지도의 레벨(확대, 축소 정도)
+    };
+    let map = new kakao.maps.Map(el, options);
+  }, []);
+
+  return (
+    <div
+      id="map"
+      className="map"
+      style={{ width: "75%", height: "40em" }}
+    ></div>
+  );
+};
+export default Reservation;


### PR DESCRIPTION
# 구현 내용
- 스터디룸 페이지 생성 후 라우터 등록
- 카카오맵 추가