### PR TITLE
그룹 서비스 - 개설 기능 Validation 테스트

### DIFF
--- a/server/services/studygroup/__test__/groupCreateValidation.test.js
+++ b/server/services/studygroup/__test__/groupCreateValidation.test.js
@@ -1,0 +1,125 @@
+function validation(data) {
+  if (data.category.length !== 2 || data.category.some(v => v === null))
+    return { isProper: false, reason: "카테고리 두 개를 선택해주세요" };
+  if (!data.title) return { isProper: false, reason: "제목을 입력해주세요" };
+  if (!data.subtitle)
+    return { isProper: false, reason: "부제목을 입력해주세요" };
+  if (!data.days.length)
+    return { isProper: false, reason: "스터디 요일을 선택해주세요" };
+  if (!data.leader) return { isProper: false, reason: "잘못된 접근입니다." };
+  if (!data.location || Object.values(data.location).length !== 2)
+    return { isProper: false, reason: "위치를 선택해주세요" };
+  return { isProper: true };
+}
+
+describe("Group Creation Input Validation", () => {
+  const successData = {
+    category: ["면접", "기술면접"],
+    leader: "dlatns0201@gmail.com",
+    tags: [],
+    title: "제목",
+    subtitle: "부제목",
+    intro: "소개 입력 폼",
+    days: [1, 2, 3],
+    startTime: 1,
+    isRecruiting: true,
+    min_personnel: 1,
+    now_personnel: 1,
+    max_personnel: 10,
+    location: { lat: 41.12, lon: -50.34 },
+    endTime: 2
+  };
+  test("normal input", () => {
+    const data = { ...successData };
+    expect(validation(data)).toEqual({ isProper: true });
+  });
+
+  describe("Category Test", () => {
+    test("Input have empty category", () => {
+      const data = { ...successData };
+      data.category = [];
+      expect(validation(data)).toEqual({
+        isProper: false,
+        reason: "카테고리 두 개를 선택해주세요"
+      });
+    });
+
+    test("Input have one category", () => {
+      const data = { ...successData };
+      data.category = ["면접"];
+      expect(validation(data)).toEqual({
+        isProper: false,
+        reason: "카테고리 두 개를 선택해주세요"
+      });
+    });
+
+    test("Input have two category, but one is null", () => {
+      const data = { ...successData };
+      data.category = [null, "면접"];
+      expect(validation(data)).toEqual({
+        isProper: false,
+        reason: "카테고리 두 개를 선택해주세요"
+      });
+    });
+  });
+
+  test("Input don't have title", () => {
+    const data = { ...successData };
+    delete data.title;
+    expect(validation(data)).toEqual({
+      isProper: false,
+      reason: "제목을 입력해주세요"
+    });
+    data.title = "";
+    expect(validation(data)).toEqual({
+      isProper: false,
+      reason: "제목을 입력해주세요"
+    });
+  });
+
+  test("Input don't have subtitle ", () => {
+    const data = { ...successData };
+    delete data.subtitle;
+    expect(validation(data)).toEqual({
+      isProper: false,
+      reason: "부제목을 입력해주세요"
+    });
+    data.subtitle = "";
+    expect(validation(data)).toEqual({
+      isProper: false,
+      reason: "부제목을 입력해주세요"
+    });
+  });
+
+  test("Input don't have days", () => {
+    const data = { ...successData };
+    data.days = [];
+    expect(validation(data)).toEqual({
+      isProper: false,
+      reason: "스터디 요일을 선택해주세요"
+    });
+  });
+
+  test("Input don't have leader email", () => {
+    const data = { ...successData };
+    delete data.leader;
+    expect(validation(data)).toEqual({
+      isProper: false,
+      reason: "잘못된 접근입니다."
+    });
+  });
+
+  test("Input don't have location info", () => {
+    const data = { ...successData };
+    delete data.location;
+    expect(validation(data)).toEqual({
+      isProper: false,
+      reason: "위치를 선택해주세요"
+    });
+    data.location = {};
+    expect(validation(data)).toEqual({
+      isProper: false,
+      reason: "위치를 선택해주세요"
+    });
+  });
+});

--- a/server/services/studygroup/package.json
+++ b/server/services/studygroup/package.json
@@ -4,12 +4,16 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "dotenv": "^8.2.0",
     "mongoose": "^5.7.13"
+  },
+  "devDependencies": {
+    "jest": "^24.9.0",
+    "supertest": "^4.0.2"
   }
 }


### PR DESCRIPTION
# 구현 내용
- 요청 데이터에 대한 Validation 테스트
- 그룹 생성, 그룹 상세 정보 조회는 비즈니스 로직이 없고, 소켓 통신으로 이루어져 유닛 테스트하기 힘들다는 결론을 냄
- supertest 모듈을 사용해 통합 테스트를 생각해보았지만, 마이크로 서비스로 인해 서버를 최소한 3개(gateway, service, manager)를 세팅한 뒤, 요청을 넣어 테스트해야 되는 번거로움으로 travis같은 ci툴을 사용하는 것이 맞다고 판단
