### PR TITLE
그룹 삭제 및 갱신 

### DIFF
--- a/client/src/components/users/groupCreate/Category.jsx
+++ b/client/src/components/users/groupCreate/Category.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from "react";
 import styled from "styled-components";
-import { category_click } from "../../../reducer/users/groupCreate";
 
 const StyledCategory = styled.ul`
   display: flex;
@@ -16,12 +15,15 @@ const StyledCategory = styled.ul`
 `;
 
 const Category = props => {
-  const { categories, dispatch, type } = props;
+  const { categories, onCategoryClick, categoryType } = props;
 
-  const categoryEvent = useCallback(e => {
-    const categoryName = e.target.textContent.trim();
-    dispatch(category_click({ categoryType: type, categoryName }));
-  }, []);
+  const categoryEvent = useCallback(
+    e => {
+      const categoryName = e.target.textContent.trim();
+      onCategoryClick(categoryType, categoryName);
+    },
+    [categoryType, onCategoryClick]
+  );
 
   return (
     <StyledCategory>

--- a/client/src/components/users/groupCreate/ScheduleInput.jsx
+++ b/client/src/components/users/groupCreate/ScheduleInput.jsx
@@ -19,8 +19,9 @@ const StyledScheduleInput = styled.div`
 `;
 
 const ScheduleInput = props => {
-  const { daysInfo, onDayDispatch, onTimeDispatch } = props;
+  const { daysInfo, onDayDispatch, onTimeDispatch, onChangeDuring } = props;
   const TimeSlot = useRef();
+  const StartTime = useRef();
 
   return (
     <StyledScheduleInput>
@@ -40,15 +41,21 @@ const ScheduleInput = props => {
       </div>
 
       <div className="time-select">
-        <select className="select" ref={TimeSlot}>
+        <select
+          className="select"
+          name="timeSlot"
+          ref={TimeSlot}
+          onChange={onTimeDispatch(TimeSlot, StartTime)}
+        >
           <option value="am">오전</option>
           <option value="pm">오후</option>
         </select>
 
         <select
           className="select"
+          ref={StartTime}
           name="startTime"
-          onChange={onTimeDispatch(TimeSlot)}
+          onChange={onTimeDispatch(TimeSlot, StartTime)}
         >
           <option value="1">1시</option>
           <option value="2">2시</option>
@@ -64,11 +71,7 @@ const ScheduleInput = props => {
           <option value="12">12시</option>
         </select>
 
-        <select
-          className="select"
-          name="during"
-          onChange={onTimeDispatch(TimeSlot)}
-        >
+        <select className="select" name="during" onChange={onChangeDuring}>
           <option value="1"> 1시간 </option>
           <option value="2"> 2시간 </option>
           <option value="3"> 3시간 </option>

--- a/client/src/components/users/groupCreate/ScheduleInput.jsx
+++ b/client/src/components/users/groupCreate/ScheduleInput.jsx
@@ -19,27 +19,8 @@ const StyledScheduleInput = styled.div`
 `;
 
 const ScheduleInput = props => {
-  const { daysInfo, dispatch } = props;
+  const { daysInfo, onDayDispatch, onTimeDispatch } = props;
   const TimeSlot = useRef();
-
-  const onClickDay = i => {
-    return e => {
-      e.target.blur();
-      dispatch(click_day(i));
-    };
-  };
-
-  const onTimeChange = useCallback(e => {
-    let time = Number.parseInt(e.target.value, 10);
-    const timeType = e.target.name;
-
-    if (timeType === "startTime") {
-      const timeSlot = TimeSlot.current.value;
-      if (timeSlot === "pm") time += 12;
-    }
-
-    dispatch(change_hour(timeType, time));
-  }, []);
 
   return (
     <StyledScheduleInput>
@@ -49,7 +30,7 @@ const ScheduleInput = props => {
             <p className="control" key={idx}>
               <button
                 className={`button is-info is-outlined ${day && day.class}`}
-                onClick={onClickDay(idx)}
+                onClick={onDayDispatch(idx)}
               >
                 {day.str}
               </button>
@@ -64,7 +45,11 @@ const ScheduleInput = props => {
           <option value="pm">오후</option>
         </select>
 
-        <select className="select" name="startTime" onChange={onTimeChange}>
+        <select
+          className="select"
+          name="startTime"
+          onChange={onTimeDispatch(TimeSlot)}
+        >
           <option value="1">1시</option>
           <option value="2">2시</option>
           <option value="3">3시</option>
@@ -79,7 +64,11 @@ const ScheduleInput = props => {
           <option value="12">12시</option>
         </select>
 
-        <select className="select" name="during" onChange={onTimeChange}>
+        <select
+          className="select"
+          name="during"
+          onChange={onTimeDispatch(TimeSlot)}
+        >
           <option value="1"> 1시간 </option>
           <option value="2"> 2시간 </option>
           <option value="3"> 3시간 </option>

--- a/client/src/components/users/groupCreate/TagInput.jsx
+++ b/client/src/components/users/groupCreate/TagInput.jsx
@@ -1,6 +1,6 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useState, useCallback } from "react";
 import styled from "styled-components";
-import { add_tag } from "../../../reducer/users/groupCreate";
 
 const StyledTagInput = styled.div`
   display: flex;
@@ -27,7 +27,7 @@ const StyledTagInput = styled.div`
 `;
 
 const TagInput = props => {
-  const { tags, dispatch } = props;
+  const { tags, onChangeTagInput } = props;
   const [inputTag, setInputTag] = useState("");
 
   const tagEvent = useCallback(
@@ -37,7 +37,7 @@ const TagInput = props => {
       setInputTag(inputData);
 
       if (lastChar === " ") {
-        if (inputData !== " ") dispatch(add_tag([...tags, inputData]));
+        if (inputData !== " ") onChangeTagInput([...tags, inputData]);
         setInputTag("");
       }
     },
@@ -48,7 +48,7 @@ const TagInput = props => {
     e => {
       if (e.keyCode === 8 && inputTag === "" && tags.length) {
         setInputTag(tags[tags.length - 1]);
-        dispatch(add_tag(tags.slice(0, tags.length - 1)));
+        onChangeTagInput(tags.slice(0, tags.length - 1));
       }
     },
     [tags, inputTag]

--- a/client/src/lib/useAxios.jsx
+++ b/client/src/lib/useAxios.jsx
@@ -18,12 +18,16 @@ export default axiosInstance => {
 
       setState({ loading: true, data: null, error: null });
 
-      axiosInstance(option)
+      return axiosInstance(option)
         .then(result => {
           const { data } = result;
           setState({ ...state, data, loading: false });
+          return data;
         })
-        .catch(error => setState({ ...state, error, loading: false }));
+        .catch(error => {
+          setState({ ...state, error, loading: false });
+          throw new Error(error);
+        });
     }
   };
 };

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useContext } from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
@@ -84,7 +85,7 @@ const MainPage = () => {
   useEffect(() => {
     isHaveCardDataWhenLoaded(loading, data) &&
       userIndexDispatch(set_groups(data));
-  }, [data, userLocation]);
+  }, [data]);
 
   return (
     <Main>

--- a/client/src/pages/users/groupCreate.jsx
+++ b/client/src/pages/users/groupCreate.jsx
@@ -13,7 +13,10 @@ import {
   initialState,
   input_content,
   change_personnel,
-  category_click
+  category_click,
+  click_day,
+  change_hour,
+  change_during
 } from "../../reducer/users/groupCreate";
 
 const StyledGroupCreate = styled.div`
@@ -69,6 +72,30 @@ const GroupCreate = () => {
 
     dispatch(input_content(contentType, description));
   }, []);
+
+  const onDayDispatch = useCallback(
+    i => e => {
+      e.target.blur();
+      dispatch(click_day(i));
+    },
+    []
+  );
+
+  const onTimeDispatch = useCallback(
+    (TimeSlot, StartTime) => e => {
+      const timeSlot = TimeSlot.current.value;
+      const selectedStartTime = Number.parseInt(StartTime.current.value, 10);
+      const resultStartTime = selectedStartTime + (timeSlot === "pm" ? 12 : 0);
+
+      dispatch(change_hour(resultStartTime));
+    },
+    []
+  );
+
+  const onChangeDuring = useCallback(e => {
+    const during = +e.target.value;
+    dispatch(change_during(during));
+  });
 
   const onChangeSlider = useCallback((min, max) => {
     dispatch(change_personnel(min, max));
@@ -160,7 +187,12 @@ const GroupCreate = () => {
 
       <TagInput tags={tags} dispatch={dispatch} />
 
-      <ScheduleInput daysInfo={daysInfo} dispatch={dispatch} />
+      <ScheduleInput
+        daysInfo={daysInfo}
+        onDayDispatch={onDayDispatch}
+        onTimeDispatch={onTimeDispatch}
+        onChangeDuring={onChangeDuring}
+      />
 
       <RangeSlider
         minRange={1}

--- a/client/src/pages/users/groupCreate.jsx
+++ b/client/src/pages/users/groupCreate.jsx
@@ -12,7 +12,8 @@ import {
   groupCreateReducer,
   initialState,
   input_content,
-  change_personnel
+  change_personnel,
+  category_click
 } from "../../reducer/users/groupCreate";
 
 const StyledGroupCreate = styled.div`
@@ -57,6 +58,10 @@ const GroupCreate = () => {
   const [state, dispatch] = useReducer(groupCreateReducer, initialState);
   const { primaryCategories, secondaryCategories, daysInfo } = state;
   const { category, tags, title, subtitle, intro } = state.data;
+
+  const onCategoryClick = useCallback((categoryType, categoryName) => {
+    dispatch(category_click(categoryType, categoryName));
+  }, []);
 
   const onChangeContent = useCallback(e => {
     const contentType = e.target.name;
@@ -113,15 +118,15 @@ const GroupCreate = () => {
       <div className="is-centered categories">
         <Category
           categories={primaryCategories}
-          type="primary"
-          dispatch={dispatch}
+          categoryType="primary"
+          onCategoryClick={onCategoryClick}
         />
 
         {category[0] && (
           <Category
             categories={secondaryCategories[category[0]]}
-            type="secondary"
-            dispatch={dispatch}
+            categoryType="secondary"
+            onCategoryClick={onCategoryClick}
           />
         )}
       </div>

--- a/client/src/pages/users/groupCreate.jsx
+++ b/client/src/pages/users/groupCreate.jsx
@@ -16,7 +16,8 @@ import {
   category_click,
   click_day,
   change_hour,
-  change_during
+  change_during,
+  add_tag
 } from "../../reducer/users/groupCreate";
 
 const StyledGroupCreate = styled.div`
@@ -80,6 +81,10 @@ const GroupCreate = () => {
     },
     []
   );
+
+  const onChangeTagInput = useCallback(tagArr => {
+    dispatch(add_tag(tagArr));
+  }, []);
 
   const onTimeDispatch = useCallback(
     (TimeSlot, StartTime) => e => {
@@ -185,7 +190,7 @@ const GroupCreate = () => {
         ></textarea>
       </div>
 
-      <TagInput tags={tags} dispatch={dispatch} />
+      <TagInput tags={tags} onChangeTagInput={onChangeTagInput} />
 
       <ScheduleInput
         daysInfo={daysInfo}

--- a/client/src/pages/users/groupDetail.jsx
+++ b/client/src/pages/users/groupDetail.jsx
@@ -17,6 +17,16 @@ const StyledGroupDetail = styled.div`
 
   width: 54rem;
   margin: 3rem auto;
+
+  .modify-buttons {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+
+    .button {
+      margin-left: 1.7rem;
+    }
+  }
 `;
 
 const GroupDetail = ({ match }) => {
@@ -28,7 +38,7 @@ const GroupDetail = ({ match }) => {
       const groupData = result.data;
       dispatch(set_detail_data(groupData));
     });
-  }, []);
+  }, [id]);
 
   const isHaveGroupData = Object.keys(groupData).length;
   const { intro } = groupData;
@@ -38,6 +48,10 @@ const GroupDetail = ({ match }) => {
         <>
           <Header groupData={groupData}></Header>
           <Main groupData={groupData} dispatch={dispatch}></Main>
+          <div className="modify-buttons">
+            <button className="button"> 수정 </button>
+            <button className="button"> 삭제 </button>
+          </div>
           <Intro intro={intro}></Intro>
         </>
       )}

--- a/client/src/pages/users/groupDetail.jsx
+++ b/client/src/pages/users/groupDetail.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useReducer, useEffect, useCallback, useContext } from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { REQUEST_URL } from "../../config.json";
 import useAxios from "../../lib/useAxios";
@@ -74,10 +75,11 @@ const GroupDetail = ({ match }) => {
               <Main groupData={groupData} dispatch={dispatch}></Main>
               {isMyGroup && (
                 <div className="modify-buttons">
-                  <button className="button"> 수정 </button>
+                  <Link to={`/group/update/${id}`}>
+                    <button className="button"> 수정 </button>
+                  </Link>
                   <button className="button" onClick={requestDelete}>
-                    {" "}
-                    삭제{" "}
+                    삭제
                   </button>
                 </div>
               )}

--- a/client/src/pages/users/groupUpdate.jsx
+++ b/client/src/pages/users/groupUpdate.jsx
@@ -16,7 +16,9 @@ import {
   initialState,
   input_content,
   change_personnel,
-  category_click
+  category_click,
+  change_hour,
+  click_day
 } from "../../reducer/users/groupUpdate";
 import { set_initial_data } from "../../reducer/users/groupUpdate.jsx";
 
@@ -82,6 +84,29 @@ const GroupCreate = ({ match }) => {
   const onCategoryClick = useCallback((categoryType, categoryName) => {
     dispatch(category_click(categoryType, categoryName));
   }, []);
+
+  const onDayDispatch = useCallback(
+    i => e => {
+      e.target.blur();
+      dispatch(click_day(i));
+    },
+    []
+  );
+
+  const onTimeDispatch = useCallback(
+    TimeSlot => e => {
+      let time = Number.parseInt(e.target.value, 10);
+      const timeType = e.target.name;
+
+      if (timeType === "startTime") {
+        const timeSlot = TimeSlot.current.value;
+        if (timeSlot === "pm") time += 12;
+      }
+
+      dispatch(change_hour(timeType, time));
+    },
+    []
+  );
 
   const onSubmit = useCallback(e => {
     //   const { data } = state;
@@ -172,7 +197,11 @@ const GroupCreate = ({ match }) => {
 
       <TagInput tags={tags} dispatch={dispatch} />
 
-      <ScheduleInput daysInfo={daysInfo} dispatch={dispatch} />
+      <ScheduleInput
+        daysInfo={daysInfo}
+        onTimeDispatch={onTimeDispatch}
+        onDayDispatch={onDayDispatch}
+      />
 
       <RangeSlider
         minRange={1}

--- a/client/src/pages/users/groupUpdate.jsx
+++ b/client/src/pages/users/groupUpdate.jsx
@@ -15,7 +15,8 @@ import {
   groupUpdateReducer,
   initialState,
   input_content,
-  change_personnel
+  change_personnel,
+  category_click
 } from "../../reducer/users/groupUpdate";
 import { set_initial_data } from "../../reducer/users/groupUpdate.jsx";
 
@@ -64,6 +65,7 @@ const GroupCreate = ({ match }) => {
 
   const [state, dispatch] = useReducer(groupUpdateReducer, initialState);
   const { primaryCategories, secondaryCategories, daysInfo } = state;
+
   const { category, tags, title, subtitle, intro } = state.data;
 
   const onChangeContent = useCallback(e => {
@@ -75,6 +77,10 @@ const GroupCreate = ({ match }) => {
 
   const onChangeSlider = useCallback((min, max) => {
     dispatch(change_personnel(min, max));
+  }, []);
+
+  const onCategoryClick = useCallback((categoryType, categoryName) => {
+    dispatch(category_click({ categoryType, categoryName }));
   }, []);
 
   const onSubmit = useCallback(e => {
@@ -124,15 +130,15 @@ const GroupCreate = ({ match }) => {
       <div className="is-centered categories">
         <Category
           categories={primaryCategories}
-          type="primary"
-          dispatch={dispatch}
+          categoryType="primary"
+          onCategoryClick={onCategoryClick}
         />
 
         {category[0] && (
           <Category
             categories={secondaryCategories[category[0]]}
-            type="secondary"
-            dispatch={dispatch}
+            categoryType="secondary"
+            onCategoryClick={onCategoryClick}
           />
         )}
       </div>

--- a/client/src/pages/users/groupUpdate.jsx
+++ b/client/src/pages/users/groupUpdate.jsx
@@ -20,6 +20,7 @@ import {
   change_hour,
   click_day,
   change_during,
+  add_tag,
   set_initial_data
 } from "../../reducer/users/groupUpdate";
 
@@ -94,12 +95,15 @@ const GroupUpdate = ({ match }) => {
     []
   );
 
+  const onChangeTagInput = useCallback(tagArr => {
+    dispatch(add_tag(tagArr));
+  }, []);
+
   const onTimeDispatch = useCallback(
     (TimeSlot, StartTime) => e => {
       const timeSlot = TimeSlot.current.value;
       const selectedStartTime = Number.parseInt(StartTime.current.value, 10);
       const resultStartTime = selectedStartTime + (timeSlot === "pm" ? 12 : 0);
-      console.log(timeSlot, selectedStartTime, resultStartTime);
 
       dispatch(change_hour(resultStartTime));
     },
@@ -198,7 +202,7 @@ const GroupUpdate = ({ match }) => {
         ></textarea>
       </div>
 
-      <TagInput tags={tags} dispatch={dispatch} />
+      <TagInput tags={tags} onChangeTagInput={onChangeTagInput} />
 
       <ScheduleInput
         daysInfo={daysInfo}

--- a/client/src/pages/users/groupUpdate.jsx
+++ b/client/src/pages/users/groupUpdate.jsx
@@ -80,7 +80,7 @@ const GroupCreate = ({ match }) => {
   }, []);
 
   const onCategoryClick = useCallback((categoryType, categoryName) => {
-    dispatch(category_click({ categoryType, categoryName }));
+    dispatch(category_click(categoryType, categoryName));
   }, []);
 
   const onSubmit = useCallback(e => {

--- a/client/src/pages/users/groupUpdate.jsx
+++ b/client/src/pages/users/groupUpdate.jsx
@@ -18,13 +18,14 @@ import {
   change_personnel,
   category_click,
   change_hour,
-  click_day
+  click_day,
+  change_during,
+  set_initial_data
 } from "../../reducer/users/groupUpdate";
-import { set_initial_data } from "../../reducer/users/groupUpdate.jsx";
 
 const apiAxios = axios.create({ baseURL: `${REQUEST_URL}/api` });
 
-const StyledGroupCreate = styled.div`
+const StyledGroupUpdate = styled.div`
   width: 60%;
   margin: 2rem auto;
 
@@ -59,7 +60,7 @@ const StyledGroupCreate = styled.div`
   }
 `;
 
-const GroupCreate = ({ match }) => {
+const GroupUpdate = ({ match }) => {
   const { userInfo } = useContext(UserContext);
   const { request } = useAxios(apiAxios);
   const { userEmail } = userInfo;
@@ -94,19 +95,21 @@ const GroupCreate = ({ match }) => {
   );
 
   const onTimeDispatch = useCallback(
-    TimeSlot => e => {
-      let time = Number.parseInt(e.target.value, 10);
-      const timeType = e.target.name;
+    (TimeSlot, StartTime) => e => {
+      const timeSlot = TimeSlot.current.value;
+      const selectedStartTime = Number.parseInt(StartTime.current.value, 10);
+      const resultStartTime = selectedStartTime + (timeSlot === "pm" ? 12 : 0);
+      console.log(timeSlot, selectedStartTime, resultStartTime);
 
-      if (timeType === "startTime") {
-        const timeSlot = TimeSlot.current.value;
-        if (timeSlot === "pm") time += 12;
-      }
-
-      dispatch(change_hour(timeType, time));
+      dispatch(change_hour(resultStartTime));
     },
     []
   );
+
+  const onChangeDuring = useCallback(e => {
+    const during = +e.target.value;
+    dispatch(change_during(during));
+  });
 
   const onSubmit = useCallback(e => {
     //   const { data } = state;
@@ -151,7 +154,7 @@ const GroupCreate = ({ match }) => {
   }, []);
 
   return (
-    <StyledGroupCreate>
+    <StyledGroupUpdate>
       <div className="is-centered categories">
         <Category
           categories={primaryCategories}
@@ -201,6 +204,7 @@ const GroupCreate = ({ match }) => {
         daysInfo={daysInfo}
         onTimeDispatch={onTimeDispatch}
         onDayDispatch={onDayDispatch}
+        onChangeDuring={onChangeDuring}
       />
 
       <RangeSlider
@@ -213,7 +217,7 @@ const GroupCreate = ({ match }) => {
         {" "}
         등록하기{" "}
       </button>
-    </StyledGroupCreate>
+    </StyledGroupUpdate>
   );
 };
 
@@ -231,4 +235,4 @@ const validation = data => {
   return { isProper: true };
 };
 
-export default GroupCreate;
+export default GroupUpdate;

--- a/client/src/pages/users/groupUpdate.jsx
+++ b/client/src/pages/users/groupUpdate.jsx
@@ -1,0 +1,199 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useCallback, useReducer, useContext, useEffect } from "react";
+import styled from "styled-components";
+import axios from "axios";
+import { REQUEST_URL } from "../../config.json";
+import useAxios from "../../lib/useAxios";
+
+import Category from "../../components/users/groupCreate/Category";
+import ImageUploader from "../../components/users/groupCreate/ImageUploader";
+import TagInput from "../../components/users/groupCreate/TagInput";
+import ScheduleInput from "../../components/users/groupCreate/ScheduleInput";
+import RangeSlider from "../../components/users/common/RangeSlider";
+import { UserContext } from "./index";
+import {
+  groupUpdateReducer,
+  initialState,
+  input_content,
+  change_personnel
+} from "../../reducer/users/groupUpdate";
+import { set_initial_data } from "../../reducer/users/groupUpdate.jsx";
+
+const apiAxios = axios.create({ baseURL: `${REQUEST_URL}/api` });
+
+const StyledGroupCreate = styled.div`
+  width: 60%;
+  margin: 2rem auto;
+
+  .categories {
+    height: 5rem;
+  }
+
+  .category {
+    cursor: pointer;
+  }
+
+  & > * {
+    margin: 0.9rem 0.6rem;
+  }
+
+  .introduction {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    margin-bottom: 1.8rem;
+
+    .textarea {
+      flex: 1;
+      min-width: 0rem;
+      margin-left: 2rem;
+      height: auto;
+    }
+  }
+
+  .button:focus {
+    background-color: white;
+  }
+`;
+
+const GroupCreate = ({ match }) => {
+  const { userInfo } = useContext(UserContext);
+  const { request } = useAxios(apiAxios);
+  const { userEmail } = userInfo;
+  const { id } = match.params;
+
+  const [state, dispatch] = useReducer(groupUpdateReducer, initialState);
+  const { primaryCategories, secondaryCategories, daysInfo } = state;
+  const { category, tags, title, subtitle, intro } = state.data;
+
+  const onChangeContent = useCallback(e => {
+    const contentType = e.target.name;
+    const description = e.target.value;
+
+    dispatch(input_content(contentType, description));
+  }, []);
+
+  const onChangeSlider = useCallback((min, max) => {
+    dispatch(change_personnel(min, max));
+  }, []);
+
+  const onSubmit = useCallback(e => {
+    //   const { data } = state;
+    //   const form = new FormData();
+    //   data.leader = userEmail;
+    //   data.location = { lat: 41.12, lon: -50.34 };
+    //   data.endTime = data.startTime + data.during;
+    //   data.endTime = data.endTime > 24 ? data.endTime - 24 : data.endTime;
+    //   let validationObj = {};
+    //   if (!(validationObj = validation(data)).isProper)
+    //     return alert(validationObj.reason);
+    //   form.append("image", data.thumbnail);
+    //   delete data.during;
+    //   delete data.thumbnail;
+    //   form.append("data", JSON.stringify(data));
+    //   axios
+    //     .post(`${REQUEST_URL}/api/studygroup/register`, form, {
+    //       headers: {
+    //         "Content-Type": "multipart/form-data"
+    //       }
+    //     })
+    //     .then(({ data }) => {
+    //       const { status } = data;
+    //       if (status === 400) return alert(data.reason);
+    //       window.location.href = "/";
+    //     })
+    //     .catch(e => {
+    //       console.error(e);
+    //       alert("에러 발생");
+    //     });
+  }, []);
+
+  useEffect(() => {
+    request("get", `/studygroup/detail/${id}`)
+      .then(data => {
+        // dispatch(set_detail_data(data));
+      })
+      .catch(err => {
+        console.error(err);
+        alert("요청 에러");
+      });
+  }, []);
+
+  return (
+    <StyledGroupCreate>
+      <div className="is-centered categories">
+        <Category
+          categories={primaryCategories}
+          type="primary"
+          dispatch={dispatch}
+        />
+
+        {category[0] && (
+          <Category
+            categories={secondaryCategories[category[0]]}
+            type="secondary"
+            dispatch={dispatch}
+          />
+        )}
+      </div>
+
+      <input
+        className="input"
+        name="title"
+        placeholder="title"
+        onChange={onChangeContent}
+        value={title}
+      />
+
+      <input
+        className="input"
+        name="subtitle"
+        placeholder="subtitle"
+        onChange={onChangeContent}
+        value={subtitle}
+      />
+
+      <div className="introduction">
+        <ImageUploader dispatch={dispatch} />
+        <textarea
+          className="textarea"
+          name="intro"
+          onChange={onChangeContent}
+          value={intro}
+          placeholder="그룹 소개"
+        ></textarea>
+      </div>
+
+      <TagInput tags={tags} dispatch={dispatch} />
+
+      <ScheduleInput daysInfo={daysInfo} dispatch={dispatch} />
+
+      <RangeSlider
+        minRange={1}
+        maxRange={10}
+        step={1}
+        onChangeSlider={onChangeSlider}
+      />
+      <button type="submit" className="button" onClick={onSubmit}>
+        {" "}
+        등록하기{" "}
+      </button>
+    </StyledGroupCreate>
+  );
+};
+
+const validation = data => {
+  if (data.category.length !== 2 || data.category.some(v => v === null))
+    return { isProper: false, reason: "카테고리 두 개를 선택해주세요" };
+  if (!data.title) return { isProper: false, reason: "제목을 입력해주세요" };
+  if (!data.subtitle)
+    return { isProper: false, reason: "부제목을 입력해주세요" };
+  if (!data.days.length)
+    return { isProper: false, reason: "스터디 요일을 선택해주세요" };
+  if (!data.leader) return { isProper: false, reason: "잘못된 접근입니다." };
+  if (!data.location || Object.values(data.location).length !== 2)
+    return { isProper: false, reason: "위치를 선택해주세요" };
+  return { isProper: true };
+};
+
+export default GroupCreate;

--- a/client/src/pages/users/index.jsx
+++ b/client/src/pages/users/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState, useReducer, createContext } from "react";
 import styled from "styled-components";
 import { Route, Switch } from "react-router-dom";
@@ -9,8 +10,9 @@ import useAxios from "../../lib/useAxios";
 import { REQUEST_URL } from "../../config.json";
 
 import MainPage from "./Main";
-import GroupDetailPage from "./groupDetail";
 import GroupCreatePage from "./groupCreate";
+import GroupUpdatePage from "./groupUpdate";
+import GroupDetailPage from "./groupDetail";
 import Header from "../../components/users/Header";
 import { initalState, userIndexReducer } from "../../reducer/users";
 import Reservation from "./reservation";
@@ -79,6 +81,7 @@ const UserPage = () => {
         <Switch>
           <Route exact path="/" component={MainPage} />
           <Route exact path="/group/create" component={GroupCreatePage} />
+          <Route exact path="/group/update/:id" component={GroupUpdatePage} />
           <Route path="/group/detail/:id" component={GroupDetailPage} />
           <Route path="/reservation" component={Reservation} />
         </Switch>

--- a/client/src/reducer/users/groupCreate.jsx
+++ b/client/src/reducer/users/groupCreate.jsx
@@ -8,7 +8,7 @@ const INPUT_CONTENT = "groupCreate/INPUT_CONTENT";
 const ATTACH_IMAGE = "groupCreate/ATTACH_IMAGE";
 const CHANGE_PERSONNEL = "groupCreate/CHANGE_PERSONNEL";
 
-export const category_click = ({ categoryType, categoryName }) => ({
+export const category_click = (categoryType, categoryName) => ({
   type: CATEGORY_CLICK,
   categoryType,
   categoryName

--- a/client/src/reducer/users/groupCreate.jsx
+++ b/client/src/reducer/users/groupCreate.jsx
@@ -4,6 +4,7 @@ const CATEGORY_CLICK = "groupCreate/CATEGORY_CLICK";
 const ADD_TAG = "groupCreate/ADD_TAG";
 const CLICK_DAY = "groupCreate/CLICK_DAY";
 const CHANGE_HOUR = "groupCreate/CHANGE_HOUR";
+const CHANGE_DURING = "groupCreate/CHANGE_DURING";
 const INPUT_CONTENT = "groupCreate/INPUT_CONTENT";
 const ATTACH_IMAGE = "groupCreate/ATTACH_IMAGE";
 const CHANGE_PERSONNEL = "groupCreate/CHANGE_PERSONNEL";
@@ -24,10 +25,14 @@ export const click_day = changedIndex => ({
   changedIndex
 });
 
-export const change_hour = (timeType, hour) => ({
+export const change_hour = startTime => ({
   type: CHANGE_HOUR,
-  timeType,
-  hour
+  startTime
+});
+
+export const change_during = during => ({
+  type: CHANGE_DURING,
+  during
 });
 
 export const input_content = (contentType, description) => ({
@@ -122,8 +127,13 @@ export const groupCreateReducer = (state, action) => {
       return { ...state, daysInfo, data };
 
     case CHANGE_HOUR:
-      const { timeType, hour } = action;
-      data[timeType] = hour;
+      const { startTime } = action;
+      data.startTime = startTime;
+      return { ...state, data };
+
+    case CHANGE_DURING:
+      const { during } = action;
+      data.during = during;
       return { ...state, data };
 
     case INPUT_CONTENT:

--- a/client/src/reducer/users/groupUpdate.jsx
+++ b/client/src/reducer/users/groupUpdate.jsx
@@ -4,6 +4,7 @@ const CATEGORY_CLICK = "groupUpdate/CATEGORY_CLICK";
 const ADD_TAG = "groupUpdate/ADD_TAG";
 const CLICK_DAY = "groupUpdate/CLICK_DAY";
 const CHANGE_HOUR = "groupUpdate/CHANGE_HOUR";
+const CHANGE_DURING = "groupUpdate/CHANGE_DURING";
 const INPUT_CONTENT = "groupUpdate/INPUT_CONTENT";
 const ATTACH_IMAGE = "groupUpdate/ATTACH_IMAGE";
 const CHANGE_PERSONNEL = "groupUpdate/CHANGE_PERSONNEL";
@@ -25,10 +26,14 @@ export const click_day = changedIndex => ({
   changedIndex
 });
 
-export const change_hour = (timeType, hour) => ({
+export const change_hour = startTime => ({
   type: CHANGE_HOUR,
-  timeType,
-  hour
+  startTime
+});
+
+export const change_during = during => ({
+  type: CHANGE_DURING,
+  during
 });
 
 export const input_content = (contentType, description) => ({
@@ -131,8 +136,13 @@ export const groupUpdateReducer = (state, action) => {
       return { ...state, daysInfo, data };
 
     case CHANGE_HOUR:
-      const { timeType, hour } = action;
-      data[timeType] = hour;
+      const { startTime } = action;
+      data.startTime = startTime;
+      return { ...state, data };
+
+    case CHANGE_DURING:
+      const { during } = action;
+      data.during = during;
       return { ...state, data };
 
     case INPUT_CONTENT:

--- a/client/src/reducer/users/groupUpdate.jsx
+++ b/client/src/reducer/users/groupUpdate.jsx
@@ -1,0 +1,157 @@
+import classnames from "classnames";
+
+const CATEGORY_CLICK = "groupUpdate/CATEGORY_CLICK";
+const ADD_TAG = "groupUpdate/ADD_TAG";
+const CLICK_DAY = "groupUpdate/CLICK_DAY";
+const CHANGE_HOUR = "groupUpdate/CHANGE_HOUR";
+const INPUT_CONTENT = "groupUpdate/INPUT_CONTENT";
+const ATTACH_IMAGE = "groupUpdate/ATTACH_IMAGE";
+const CHANGE_PERSONNEL = "groupUpdate/CHANGE_PERSONNEL";
+const SET_INITIAL_DATA = "groupUpdate/SET_INITIAL_DATA";
+
+export const category_click = ({ categoryType, categoryName }) => ({
+  type: CATEGORY_CLICK,
+  categoryType,
+  categoryName
+});
+
+export const add_tag = tags => ({
+  type: ADD_TAG,
+  tags
+});
+
+export const click_day = changedIndex => ({
+  type: CLICK_DAY,
+  changedIndex
+});
+
+export const change_hour = (timeType, hour) => ({
+  type: CHANGE_HOUR,
+  timeType,
+  hour
+});
+
+export const input_content = (contentType, description) => ({
+  type: INPUT_CONTENT,
+  contentType,
+  description
+});
+
+export const attach_image = file => ({
+  type: ATTACH_IMAGE,
+  file
+});
+
+export const change_personnel = (min_personnel, max_personnel) => ({
+  type: CHANGE_PERSONNEL,
+  min_personnel,
+  max_personnel
+});
+
+export const set_initial_data = groupData => ({
+  type: SET_INITIAL_DATA,
+  groupData
+});
+
+const daysStr = ["일", "월", "화", "수", "목", "금", "토"];
+const daysInfo = daysStr.map(str => ({
+  isSelected: false,
+  class: classnames({ "is-focused": false }),
+  str
+}));
+
+export const initialState = {
+  primaryCategories: ["프로그래밍", "자격증", "외국어", "면접", "지역"],
+  secondaryCategories: {
+    프로그래밍: ["C++", "Java", "JavaScript"],
+    자격증: ["IT", "운전", "보건", "식품"],
+    외국어: ["영어", "중국어", "불어", "스페인어"],
+    면접: ["공채", "상시채용", "특채", "기술면접", "임원면접"],
+    지역: ["경기도", "서울", "울산", "인천", "광주", "부산"]
+  },
+  daysInfo,
+  data: {
+    category: [],
+    leader: "",
+    tags: [],
+    title: "",
+    subtitle: "",
+    intro: "",
+    days: [],
+    startTime: 1,
+    during: 1,
+    isRecruiting: true,
+    thumbnail: null,
+    min_personnel: 1,
+    now_personnel: 1,
+    max_personnel: 10,
+    location: { lat: null, lon: null }
+  }
+};
+
+export const groupUpdateReducer = (state, action) => {
+  let data = state.data;
+  switch (action.type) {
+    case SET_INITIAL_DATA:
+      return action.groupData;
+
+    case CATEGORY_CLICK:
+      const { categoryType, categoryName } = action;
+      if (categoryType === "primary") {
+        data.category = [categoryName, null];
+      }
+
+      if (categoryType === "secondary") {
+        const category = [...data.category];
+        category[1] = categoryName;
+        data.category = category;
+      }
+
+      return { ...state, data };
+
+    case ADD_TAG:
+      data.tags = action.tags;
+      return { ...state, data };
+
+    case CLICK_DAY:
+      const idx = action.changedIndex;
+      const daysInfo = [...state.daysInfo];
+      const isSelected = daysInfo[idx].isSelected;
+
+      daysInfo[idx] = {
+        str: daysInfo[idx].str,
+        isSelected: !isSelected,
+        class: classnames({
+          "is-focused": !isSelected
+        })
+      };
+
+      if (isSelected) data.days = data.days.filter(day => day !== idx);
+      else data.days.push(idx);
+      return { ...state, daysInfo, data };
+
+    case CHANGE_HOUR:
+      const { timeType, hour } = action;
+      data[timeType] = hour;
+      return { ...state, data };
+
+    case INPUT_CONTENT:
+      const { contentType, description } = action;
+      data[contentType] = description;
+
+      return { ...state, data };
+
+    case ATTACH_IMAGE:
+      data.thumbnail = action.file;
+
+      return { ...state, data };
+
+    case CHANGE_PERSONNEL:
+      const { min_personnel, max_personnel } = action;
+      data = { ...data, min_personnel, max_personnel };
+      return { ...state, data };
+
+    default:
+      return state;
+  }
+};

--- a/client/src/reducer/users/groupUpdate.jsx
+++ b/client/src/reducer/users/groupUpdate.jsx
@@ -9,7 +9,7 @@ const ATTACH_IMAGE = "groupUpdate/ATTACH_IMAGE";
 const CHANGE_PERSONNEL = "groupUpdate/CHANGE_PERSONNEL";
 const SET_INITIAL_DATA = "groupUpdate/SET_INITIAL_DATA";
 
-export const category_click = ({ categoryType, categoryName }) => ({
+export const category_click = (categoryType, categoryName) => ({
   type: CATEGORY_CLICK,
   categoryType,
   categoryName


### PR DESCRIPTION
# 구현 내용
- 그룹 삭제, 수정 버튼 작성(스터디 장에게만 보이는 조건문 포함)
- use_axios에서 프로미스 결과값 지원
- 그룹 삭제 작성 완료
- 그룹 수정 뷰와 상태를 그룹 개설 컴포넌트로 재사용하기 위한 리팩토링
  - 부모 컴포넌트에서 dispatch안에 액션 생성 함수를 포함시키고, 액션 생성 함수의 인자를 입력 받는 함수를 props로 전달하는 방식으로 리팩토링
- 스터디 시간 선택 시, timeSlot(오전, 오후)를 변경한 후, 시간을 선택하지 않았을 때 상태가 변경되지 않는 점 ref를 인자로 사용한 함수로 픽스
- 리팩토링 요소
  - 카테고리 선택
  - 태그 입력 폼
  - 요일 선택 및 스터디 시간

# 아직 하지 못한 것
- 그룹 개설 및 수정 페이지의 카테고리 선택 css 적용
- 그룹 수정 페이지 mount시, 데이터 요청
  - 데이터 요청한 것을 기반으로 입력 폼 및 요소들 value 초기화

# 심화적으로 고려할 점
- 그룹 개설 및 수정 페이지와 reducer의 많은 코드의 중복으로 하나의 컴포넌트로 만들 필요가 있음
- 입력 폼 또는, 카테고리 선택에 대해서, 커스텀 훅을 만들어 코드 정리를 할 필요가 있음
- 수정 시, 개설과 다르게 mount시, thumbnail이 url로 되어 있어, 수정하지 않으면 url형태의 string으로, 수정하면 File로 상태가 변경되므로, 서버와 합의해 핸들링 할 필요가 있음

