### PR TITLE
그룹 삭제에 대한 요청 응답

### DIFF
--- a/server/api-gateway/routes/api/studyGroup/ctrl.js
+++ b/server/api-gateway/routes/api/studyGroup/ctrl.js
@@ -88,6 +88,23 @@ exports.sendGetGroupDetailPacket = apigateway => (req, res, next) => {
   next();
 };
 
+exports.sendDeleteGroupPacket = apigateway => (req, res, next) => {
+  const { id } = req.params;
+
+  const packet = makePacket(
+    "GET",
+    "removeGroup",
+    "removeGroup",
+    { id },
+    {},
+    req.resKey,
+    apigateway.context
+  );
+
+  req.packet = packet;
+  next();
+};
+
 function validation(data) {
   if (data.category.length !== 2 || data.category.some(v => v === null))
     return { isProper: false, reason: "카테고리 두 개를 선택해주세요" };

--- a/server/api-gateway/routes/api/studyGroup/index.js
+++ b/server/api-gateway/routes/api/studyGroup/index.js
@@ -6,7 +6,8 @@ const {
   registerValidation,
   uploadToImage,
   sendGroupCreationPacket,
-  sendGetGroupDetailPacket
+  sendGetGroupDetailPacket,
+  sendDeleteGroupPacket
 } = require("./ctrl");
 
 const {
@@ -34,6 +35,7 @@ module.exports = function(apigateway) {
   );
 
   router.get("/detail/:id", sendGetGroupDetailPacket(apigateway));
+  router.delete("/detail/:id", sendDeleteGroupPacket(apigateway));
 
   return router;
 };

--- a/server/services/studygroup/StudyGroup.js
+++ b/server/services/studygroup/StudyGroup.js
@@ -44,6 +44,19 @@ class StudyGroup extends App {
         }
         break;
 
+      case "removeGroup":
+        try {
+          const { id } = params;
+          await StudyGroups.findByIdAndDelete(id);
+
+          replyData.method = "REPLY";
+          replyData.body = { status: 200 };
+        } catch (e) {
+          console.error(e);
+          replyData.method = "ERROR";
+          replyData.body = e;
+        }
+
       default:
         break;
     }


### PR DESCRIPTION
# 구현 내용
- gateway: 그룹 삭제 라우터 작성
- service: 그룹 삭제 요청에 대해 DB에 접근해 데이터 삭제

# 해야할 것
- 그룹 삭제에 대한 소켓 통신 프로토콜 명세
- 그룹 삭제 후, 탐색 서비스 DB와 연동하기 위해 엘라스틱 서치 모듈과 연동
- 그룹 수정에 대한 라우터 및 DB 접근 서비스 작성
  - 그룹 수정으로 DB의 데이터 수정 후, 엘라트식 서치 모듈과 연동

# 심화적으로 고려할 점
- 그룹 수정 시, body의 속성인 thumbnail이 file인지, url인지 판단해, 변경되었는지 판단해 Object Storage에 업로드할지 결정
- 그룹 수정, 삭제에 대한 API 콜 통합 테스트 작성
