### PR TITLE
그룹 입력(개설 및 수정) 카테고리 선택 시, css 적용

### DIFF
--- a/client/src/components/users/groupCreate/Category.jsx
+++ b/client/src/components/users/groupCreate/Category.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import styled from "styled-components";
 
 const StyledCategory = styled.ul`
@@ -11,24 +11,40 @@ const StyledCategory = styled.ul`
     font-weight: bold;
     font-size: 1.4rem;
     margin: 0.2rem 1rem;
+
+    &.selected {
+      color: red;
+    }
   }
 `;
 
 const Category = props => {
   const { categories, onCategoryClick, categoryType } = props;
+  const [categoryIdx, setCategoryIdx] = useState(-1);
+  const isSelectedIdx = useCallback(idx => categoryIdx === idx, [categoryIdx]);
 
   const categoryEvent = useCallback(
-    e => {
+    idx => e => {
       const categoryName = e.target.textContent.trim();
       onCategoryClick(categoryType, categoryName);
+      setCategoryIdx(idx);
     },
     [categoryType, onCategoryClick]
   );
 
+  useEffect(() => {
+    if (categoryType !== "secondary") return;
+    setCategoryIdx(-1);
+  }, [categories]);
+
   return (
     <StyledCategory>
-      {categories.map(category => (
-        <li key={category} onClick={categoryEvent}>
+      {categories.map((category, idx) => (
+        <li
+          key={category}
+          className={isSelectedIdx(idx) ? "selected" : ""}
+          onClick={categoryEvent(idx)}
+        >
           {category}
         </li>
       ))}


### PR DESCRIPTION
카테고리 컴포넌트 내에서 자신의 인덱스 정보 상태를 저장
-1값이 default며, 0부터 해당된다.
useEffect에서 categories에 의존성을 주어 주 카테고리가 바뀔 때 인덱스 상태를 -1로 초기화하게 한다.
categories = 선택된 주 카테고리에 속한 부 카테고리 리스트

<!-- reviewer와 Assignees를 설정했는지 확인해주세요 -->
<!-- 제발!!!! 구현 내용을 자세하게 적어주세요😣 -->
<!-- ✨✨✨테스트 코드를 작성하였는지 확인해주세요✨✨✨ -->
<!-- 🚀 서비스 브랜치 -> develop 브랜치 로 최신 동기화 작업을 위한 PR이라면 "MergeToDevelop" 라벨을 달아주세요-->
<!-- 🚀 develop 브랜치 -> 서비스 브랜치 로 최신 동기화 작업을 위한 PR이라면 "서비스업데이트" 라벨을 달아주세요-->

