### PR TITLE
로그 서비스 duration측정 기능 추가, error packet 처리

### DIFF
--- a/server/lib/tcp/App.js
+++ b/server/lib/tcp/App.js
@@ -35,8 +35,10 @@ class App extends TcpServer {
   }
 
   async onRead(socket, data) {
-    if (Object.prototype.hasOwnProperty.call(data, "nextQuery")) {
-      this.sendTcpLog(data.nextQuery);
+    if (!isLogService(this.context.name) && data.hasOwnProperty("nextQuery")) {
+      const spanId = await this.sendTcpLog(data.nextQuery);
+
+      data.spanId = spanId;
     }
 
     this.job(socket, data);

--- a/server/lib/tcp/App.js
+++ b/server/lib/tcp/App.js
@@ -44,7 +44,7 @@ class App extends TcpServer {
     this.job(socket, data);
   }
 
-  send(appClient, data) {
+  async send(appClient, data) {
     const packet = makePacket(
       data.method,
       data.curQuery,
@@ -60,6 +60,9 @@ class App extends TcpServer {
       this.ApiGateway.write(packet);
     } else {
       appClient.write(packet);
+    }
+    if (!isLogService(data.info.name) && data.spanId) {
+      await this.sendTcpLog(data.curQuery, data.spanId);
     }
   }
 

--- a/server/lib/tcp/App.js
+++ b/server/lib/tcp/App.js
@@ -16,6 +16,7 @@ class App extends TcpServer {
 
     this.sendTcpLog = makeLogSender.call(this, "tcp");
     (async () => {
+      if (name === process.env.LOG_NAME) return;
       await new Promise(res => this.connectToLogService(res));
       this.doMessageJob();
     })();

--- a/server/lib/tcp/App.js
+++ b/server/lib/tcp/App.js
@@ -1,6 +1,6 @@
 const TcpServer = require("./tcpServer");
 const TcpClient = require("./tcpClient");
-const { makePacket, isLogService } = require("../tcp/util");
+const { makePacket, isLogService, isErrorPacket } = require("../tcp/util");
 const { getAppbyName, getAllApps, popMessageQueue } = require("../redis");
 const { makeLogSender } = require("./logUtils");
 
@@ -62,6 +62,14 @@ class App extends TcpServer {
       appClient.write(packet);
     }
     if (!isLogService(data.info.name) && data.spanId) {
+      if (isErrorPacket(data.method)) {
+        await this.sendTcpLog(data.curQuery, {
+          spanId: data.spanId,
+          error: data.method,
+          errorMsg: data.body.msg
+        });
+        return;
+      }
       await this.sendTcpLog(data.curQuery, data.spanId);
     }
   }

--- a/server/lib/tcp/App.js
+++ b/server/lib/tcp/App.js
@@ -65,7 +65,7 @@ class App extends TcpServer {
       if (isErrorPacket(data.method)) {
         await this.sendTcpLog(data.curQuery, {
           spanId: data.spanId,
-          error: data.method,
+          errors: data.method,
           errorMsg: data.body.msg
         });
         return;

--- a/server/lib/tcp/App.js
+++ b/server/lib/tcp/App.js
@@ -1,6 +1,6 @@
 const TcpServer = require("./tcpServer");
 const TcpClient = require("./tcpClient");
-const { makePacket } = require("../tcp/util");
+const { makePacket, isLogService } = require("../tcp/util");
 const { getAppbyName, getAllApps, popMessageQueue } = require("../redis");
 const { makeLogSender } = require("./logUtils");
 
@@ -16,7 +16,7 @@ class App extends TcpServer {
 
     this.sendTcpLog = makeLogSender.call(this, "tcp");
     (async () => {
-      if (name === process.env.LOG_NAME) return;
+      if (isLogService(name)) return;
       await new Promise(res => this.connectToLogService(res));
       this.doMessageJob();
     })();

--- a/server/lib/tcp/logUtils.js
+++ b/server/lib/tcp/logUtils.js
@@ -19,19 +19,29 @@ function makeLogSender(networkType) {
 
   switch (networkType) {
     case "tcp":
-      return async function send(query, ...possessedSpanId) {
+      return async function send(query, ...restData) {
         const timestamp = Date.now();
         let spanId;
+        let errorMsg;
+        let error;
 
-        if (possessedSpanId[0]) spanId = possessedSpanId[0];
-        else {
+        if (restData[0]) {
+          const restObject = restData[0];
+          if (restObject.hasOwnProperty("spanId")) spanId = restObject.spanId;
+          if (restObject.hasOwnProperty("error")) {
+            error = restObject.error;
+            errorMsg = restObject.errorMsg;
+          }
+        } else {
           spanId = await generateId(timestamp);
         }
         const logData = {
           query,
           spanId,
           service: name,
-          timestamp
+          timestamp,
+          error,
+          errorMsg
         };
 
         this.logService.write(

--- a/server/lib/tcp/logUtils.js
+++ b/server/lib/tcp/logUtils.js
@@ -59,12 +59,12 @@ function makeLogSender(networkType) {
         return spanId;
       };
     case "http":
-      return function send(httpPathandMethod) {
-        const timestamp = Math.floor(Date.now() / 1);
+      return async function send(httpLogData) {
+        const timestamp = Date.now();
+
         const logData = {
-          ...httpPathandMethod,
-          spanId: generateId(timestamp),
-          service: this.name,
+          ...httpLogData,
+          service: "gateway",
           timestamp
         };
 

--- a/server/lib/tcp/util.js
+++ b/server/lib/tcp/util.js
@@ -36,4 +36,9 @@ exports.makePacket = (
   return JSON.stringify(packet) + PACKET_SPLITTER;
 };
 
+exports.isLogService = name => {
+  if (name === process.env.LOG_NAME) return true;
+  return false;
+};
+
 exports.PACKET_SPLITTER = PACKET_SPLITTER;

--- a/server/lib/tcp/util.js
+++ b/server/lib/tcp/util.js
@@ -41,4 +41,10 @@ exports.isLogService = name => {
   return false;
 };
 
+exports.isErrorPacket = method => {
+  if (method === this.ERROR_PACKET_CODE) return true;
+  return false;
+};
 exports.PACKET_SPLITTER = PACKET_SPLITTER;
+
+exports.ERROR_PACKET_CODE = "ERROR";

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5047,9 +5047,9 @@
       }
     },
     "mongoose": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.0.tgz",
-      "integrity": "sha512-+VqrLGmHoDW/72yaXgiXSF7E/JcZ8Iyt7etrd4x3+Bj0z7k6GHHUBgGHP5ySPoG4J412RFuvHqx6xEOIuUrcfQ==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.8.1.tgz",
+      "integrity": "sha512-8Cffl52cMK2iBlpLipoRKW/RdrhkxvVzXsy+xVsfbKHQBCWkFiS0T0jU4smYzomTMP4gW0sReJoRA7Gu/7VVgQ==",
       "requires": {
         "bson": "~1.1.1",
         "kareem": "2.3.1",
@@ -5173,9 +5173,9 @@
       }
     },
     "nodemon": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.1.tgz",
-      "integrity": "sha512-UC6FVhNLXjbbV4UzaXA3wUdbEkUZzLGgMGzmxvWAex5nzib/jhcSHVFlQODdbuUHq8SnnZ4/EABBAbC3RplvPg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.2.tgz",
+      "integrity": "sha512-GWhYPMfde2+M0FsHnggIHXTqPDHXia32HRhh6H0d75Mt9FKUoCBvumNHr7LdrpPBTKxsWmIEOjoN+P4IU6Hcaw==",
       "dev": true,
       "requires": {
         "chokidar": "^3.2.2",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
     "eslint-config-naver": "^2.1.0",
     "eslint-config-prettier": "^6.7.0",
     "jest": "^24.9.0",
-    "mongoose": "^5.7.12",
+    "mongoose": "^5.8.1",
     "redis": "^2.8.0"
   },
   "devDependencies": {
@@ -16,7 +16,7 @@
     "@commitlint/config-conventional": "^7.5.0",
     "eslint": "^6.7.2",
     "husky": "^1.3.1",
-    "nodemon": "^2.0.1"
+    "nodemon": "^2.0.2"
   },
   "scripts": {
     "test": "jest --detectOpenHandles --forceExit"

--- a/server/services/log/index.js
+++ b/server/services/log/index.js
@@ -1,4 +1,5 @@
 require("dotenv").config({ path: ".env" });
+const App = require("../../lib/tcp/App");
 const { LOG_PORT, LOG_HOST, LOG_NAME } = process.env;
 const elasticsearch = require("elasticsearch");
 const elasticClient = new elasticsearch.Client({
@@ -45,6 +46,11 @@ class LogService extends require("../../lib/tcp/App") {
   }
 }
 
-const logService = new LogService(LOG_NAME, LOG_HOST, LOG_PORT);
+class LogService extends App {
+  constructor(name, host, port) {
+    super(name, host, port, jobEexcutor);
+    this.logMap = {};
+  }
+}
 
-// logService.connectToAppListManager();
+const logService = new LogService(LOG_NAME, LOG_HOST, LOG_PORT);

--- a/server/services/log/index.js
+++ b/server/services/log/index.js
@@ -7,31 +7,41 @@ const elasticClient = new elasticsearch.Client({
   log: "trace"
 });
 
-/**
- * TODO: elasticsearch로 데이터 정제하여 보내기
- */
-class LogService extends require("../../lib/tcp/App") {
-  constructor(name, host, port) {
-    super(name, host, port);
-    this.query = [];
-    this.logMap = {};
-  }
+function durationEndDataIsCome(spanId) {
+  if (this.logMap.hasOwnProperty(spanId)) return true;
+  return false;
+}
 
-  async onRead(socket, data) {
-    const { method, nextQuery, body } = data;
-    // console.log(data);
-    const { timestamp } = body.data;
+function sendLog(logPacket, spanId) {
+  console.log(`log Packtet ${JSON.stringify(logPacket)}`);
+  console.log("before delete log map", this.logMap);
+  new Promise(resolve => resolve(JSON.stringify(logPacket))).then(JSONData => {
+    elasticClient.index({
+      index: "test",
+      body: JSONData,
+      id: logPacket.timestamp
+    });
+    delete this.logMap[spanId];
+    console.log(`after delete log in map \n`, this.logMap);
+  });
+}
 
-    const jsonData = await new Promise(resolve =>
-      resolve(JSON.stringify(body.data))
-    );
+function calculateDuration(spanId, durationEndData) {
+  console.log("durationEndData is COME!!!!!!!!!!", spanId, durationEndData);
 
-    if (nextQuery === "log" && method === "POST") {
-      elasticClient.index({
-        index: "test",
-        body: jsonData,
-        id: timestamp
-      });
+  const durationStartData = this.logMap[spanId];
+  const durationStart = durationStartData.timestamp;
+  const durationEnd = durationEndData.timestamp;
+
+  const duration = durationEnd - durationStart;
+
+  console.log(`--------------------------- duration is ${duration}`);
+
+  const logPacket = { ...durationStartData, duration };
+
+  sendLog.call(this, logPacket, spanId);
+}
+
 async function doJob(_socket, data) {
   const { method, nextQuery, body } = data;
 

--- a/server/services/log/index.js
+++ b/server/services/log/index.js
@@ -37,12 +37,8 @@ function calculateDuration(spanId, durationEndData) {
 
   console.log(`--------------------------- duration is ${duration}`);
 
-  const logPacket = { ...durationStartData, duration };
+  const logPacket = { ...durationEndData, ...durationStartData, duration };
 
-  if (durationEndData.hasOwnProperty("errorMsg")) {
-    logPacket.errorMsg = durationEndData.errorMsg;
-    logPacket.errors = durationEndData.error;
-  }
   sendLog.call(this, logPacket, spanId);
 }
 

--- a/server/services/log/index.js
+++ b/server/services/log/index.js
@@ -39,13 +39,17 @@ function calculateDuration(spanId, durationEndData) {
 
   const logPacket = { ...durationStartData, duration };
 
+  if (durationEndData.hasOwnProperty("errorMsg")) {
+    logPacket.errorMsg = durationEndData.errorMsg;
+    logPacket.errors = durationEndData.error;
+  }
   sendLog.call(this, logPacket, spanId);
 }
 
 async function doJob(_socket, data) {
   const { method, nextQuery, body } = data;
 
-  const { timestamp, spanId } = body.data;
+  const { spanId } = body.data;
 
   if (nextQuery === "log" && method === "POST") {
     if (durationEndDataIsCome.call(this, spanId)) {

--- a/server/services/log/index.js
+++ b/server/services/log/index.js
@@ -32,23 +32,23 @@ class LogService extends require("../../lib/tcp/App") {
         body: jsonData,
         id: timestamp
       });
-    }
-    // const replyPacket = makePacket(
-    //   "REPLY",
-    //   "log",
-    //   {},
-    //   { data: "it's finall data" },
-    //   key,
-    //   this.context
-    // );
+async function doJob(_socket, data) {
+  const { method, nextQuery, body } = data;
 
-    // socket.write(replyPacket);
+  const { timestamp, spanId } = body.data;
+
+  if (nextQuery === "log" && method === "POST") {
+    if (durationEndDataIsCome.call(this, spanId)) {
+      calculateDuration.call(this, spanId, body.data);
+    } else {
+      this.logMap[spanId] = body.data;
+    }
   }
 }
 
 class LogService extends App {
   constructor(name, host, port) {
-    super(name, host, port, jobEexcutor);
+    super(name, host, port, doJob);
     this.logMap = {};
   }
 }


### PR DESCRIPTION
<!-- reviewer와 Assignees를 설정했는지 확인해주세요 -->
<!-- 제발!!!! 구현 내용을 자세하게 적어주세요😣 -->
<!-- ✨✨✨테스트 코드를 작성하였는지 확인해주세요✨✨✨ -->
<!-- 🚀 서비스 브랜치 -> develop 브랜치 로 최신 동기화 작업을 위한 PR이라면 "MergeToDevelop" 라벨을 달아주세요-->
<!-- 🚀 develop 브랜치 -> 서비스 브랜치 로 최신 동기화 작업을 위한 PR이라면 "서비스업데이트" 라벨을 달아주세요-->

# 구현 내용
- 서비스가 요청받은 쿼리를 수행하는 duration을 측정한다.
- 로그서비스 내부에 log map을 두고 spanid(uuid)를 키로 로그 정보를 저장한다.
- map에 존재하는 spanid가 들어오면 duration을 구하고 로그 패킷을 elasticsearch로 전송한다. 

