### PR TITLE
결제 서비스의 쿼리 기능 작성 (1. inspectQueue, 2. approvePayment, 3. removeInQueue)

### DIFF
--- a/server/services/payment/Payment.js
+++ b/server/services/payment/Payment.js
@@ -1,8 +1,8 @@
 const App = require("../../lib/tcp/App");
 const mongoose = require("mongoose");
 const { PAYMENTS_MONGO_URL } = process.env;
-const { inspectQueue } = require("./query/queries");
-const queryMap = { inspectQueue };
+const { inspectQueue, approvePayment } = require("./query/queries");
+const queryMap = { inspectQueue, approvePayment };
 
 mongoose
   .connect(PAYMENTS_MONGO_URL, {

--- a/server/services/payment/README.md
+++ b/server/services/payment/README.md
@@ -1,69 +1,102 @@
 # 결제 서비스
+
 사용자들의 중복 결제를 방지하고, 결제 내역을 저장하는 서비스 입니다.
 
 ## Query
-|  No.  |     From      |     Query      |    To     |   Description    |
-| :---: | :-----------: | :------------: | :-------: | :--------------: |
-|   1   |   `gateway`   | `inspectQueue` | `gateway` |     결제 큐를 확인     |
-|   2   |   `gateway`   |   `payStart`   | `gateway` |  결제 시작을 알리는 요청   |
-|   3   | `reservation` |    `payEnd`    | `gateway` | 결제 후 예약 저장까지 마무리 |
-|   4   |   `gateway`   |    `cancel`    | `gateway` |  결제 취소 후 리다이렉트   |
-|   5   |   `gateway`   |     `fail`     | `gateway` |  결제 실패 후 리다이렉트   |
+
+| No. |     From      |         Query          |      To       |     Description      |
+| :-: | :-----------: | :--------------------: | :-----------: | :------------------: |
+|  1  |   `gateway`   |     `inspectQueue`     |   `gateway`   |    결제 큐를 확인    |
+|  2  |   `gateway`   |    `approvePayment`    | `reservation` |    결제 승인 요청    |
+|  3  | `reservation` | `removePaymentInQueue` |   `gateway`   | 예약 추가 후 결제 큐 |
 
 ### 1. payRead
+
 사용자가 결제를 시작하기 전에 예약하려는 스터디룸이 예약 가능한지 확인
+
 - Parmas
-```js
+
+```
 {
 	userInfo: {
 		kakaoAccessToken, // String 카카오 access_token
 		userId // 사용자 id
 	},
 	paymentInfo: {
-		cid, //	String	가맹점 코드. 10자
-		partner_order_id, //	String	가맹점 주문번호. 최대 100자
+		cid, //	String 가맹점 코드. 10자
+		partner_order_id, // String	가맹점 주문번호. 최대 100자
 		partner_user_id, //	String	가맹점 회원 id. 최대 100자
 		item_name, //	String	상품명. 최대 100자
-		quantity, //	Number	상품 수량
-		total_amount, //	Number	상품 총액
+		quantity, // Number	상품 수량
+		total_amount, // Number	상품 총액
 		tax_free_amount, //	Number	상품 비과세 금액
-		approval_url, //	String	결제 성공시 redirect url. 최대 255자
-		cancel_url, //	String	결제 취소시 redirect url. 최대 255자
+		approval_url, // String	결제 성공시 redirect url. 최대 255자
+		cancel_url, // String	결제 취소시 redirect url. 최대 255자
 		fail_url // String	결제 실패시 redirect url. 최대 255자
 	},
 	reservationInfo: {
 		day, //	Number[]	예약 요일
-		startTime, //	Number[]	요일별 시작 시간을 저장
-		endTime, //	Number[]	요일별 끝나는 시간을 저장
+		startTime, //	Number[] 요일별 시작 시간을 저장
+		endTime, //	Number[] 요일별 끝나는 시간을 저장
 		roomId, // ObjectId	결제하려는 스터디룸의 id
 	}
 }
 ```
 
-### 2. payStart
+### 2. approvePayment
+
+사용자의 결제 행동 후 결제 승인 요청
+
 - Params
-```json
-{}
+
+```
+{
+	pg_token, // 결제 승인 인증 토큰
+	userId, // 사용자 id
+	roomId // 스터디룸 id
+}
 ```
 
-- Req
-```json
-{}
+### 3. removePaymentInQueue
+
+결제 큐에서 결제 정보를 삭제
+
+- Parmas
+
 ```
-
-### 3. payEnd
-카카오페이 성공 이후에 예약 정보까지 저장한 후 결제 큐에서 결제 완료한 스터디룸 정보를 삭제
-
-### 4. cancel
-카카오페이가 취소 되었을 경우 결제 큐를 업데이트
-
-### 5. fail
-카카오페이가 실패했을 경우 결제 큐를 업데이트
-
+{
+	userId, // 사용자 id
+	roomId // 스터디룸 id
+}
+```
 
 ## Database Schema
 
 ### 결제 큐 (in memory)
+
 결제 큐는 동시에 같은 스터디 룸에 예약하는 것을 방지하는 구조체입니다. 자세한 내용은 [여기]()에 있습니다.
 
 ### 결제 내역 모델 (MongoDB)
+
+```js
+const PaymentSchema = new Schema({
+  aid: String, // Request 고유 번호
+  amount: {
+    discount: Number, // 할인 금액
+    point: Number, //	사용한 포인트 금액
+    tax_free: Number, // 비과세 금액
+    total: Number, // 전체 결제 금액
+    vat: Number // 사용한 포인트 금액
+  },
+  approved_at: Date, // 결제 승인 시각
+  cid: String, // 가맹점 코드
+  created_at: Date, // 결제 준비 요청 시각
+  item_name: String, // 상품 이름. 최대 100자
+  partner_order_id: String, // 가맹점 주문번호
+  partner_user_id: String, // 가맹점 회원 id
+  payment_method_type: String, // 결제 수단. CARD, MONEY 중 하나
+  quantity: Number, // 상품 수량
+  tid: String, // 결제 고유 번호
+  userId: String // 사용자 id
+});
+```

--- a/server/services/payment/model/payment.js
+++ b/server/services/payment/model/payment.js
@@ -1,0 +1,27 @@
+const mongoose = require("mongoose");
+const { Schema } = mongoose;
+
+const PaymentSchema = new Schema({
+  aid: String, // Request 고유 번호
+  amount: {
+    discount: Number, // 할인 금액
+    point: Number, //	사용한 포인트 금액
+    tax_free: Number, // 비과세 금액
+    total: Number, // 전체 결제 금액
+    vat: Number // 사용한 포인트 금액
+  },
+  approved_at: Date, // 결제 승인 시각
+  cid: String, // 가맹점 코드
+  created_at: Date, // 결제 준비 요청 시각
+  item_name: String, // 상품 이름. 최대 100자
+  partner_order_id: String, // 가맹점 주문번호
+  partner_user_id: String, // 가맹점 회원 id
+  payment_method_type: String, // 결제 수단. CARD, MONEY 중 하나
+  quantity: Number, // 상품 수량
+  tid: String, // 결제 고유 번호
+  userId: String
+});
+
+const Payment = mongoose.model("payment", PaymentSchema, "payments");
+
+module.exports = Payment;

--- a/server/services/payment/query/queries.js
+++ b/server/services/payment/query/queries.js
@@ -20,7 +20,10 @@ exports.inspectQueue = async ({ userId, paymentInfo, reservationInfo }) => {
     sameRoomIdInPayQueue.length === 0 ||
     avoidReservationCollision({ day, startTime, endTime }, sameRoomIdInPayQueue)
   ) {
-    nextUrl = await getNextUrl(roomId, userId, paymentInfo);
+    const res = await getNextUrl(roomId, userId, paymentInfo);
+
+    nextUrl = res.nextUrl;
+    paymentInfo.tid = res.tid;
 
     if (nextUrl) {
       payQueue[roomId].push({

--- a/server/services/payment/query/queries.js
+++ b/server/services/payment/query/queries.js
@@ -49,7 +49,7 @@ exports.inspectQueue = async ({ userId, paymentInfo, reservationInfo }) => {
       endQuery: "inspectQueue",
       params: {}
     },
-    body: { nextUrl }
+    body: { nextUrl, status: 200 }
   };
 };
 
@@ -72,11 +72,11 @@ exports.approvePayment = async ({ pg_token, userId, roomId }) => {
       headers: {
         method: "REPLY",
         curQuery: "approvePayment",
-        nextQuery: "gateway",
-        endQuery: "gateway",
+        nextQuery: "apigateway",
+        endQuery: "apigateway",
         params: {}
       },
-      body: {}
+      body: { err: true, msg: "결제 승인 에러", status: 400 }
     };
   }
 
@@ -91,5 +91,25 @@ exports.approvePayment = async ({ pg_token, userId, roomId }) => {
       params: { reservationInfo, userId }
     },
     body: {}
+  };
+};
+
+exports.removeInQueue = ({ roomId, userId }) => {
+  const idxToDelete = payQueue[roomId].findIndex(
+    element => element.userId === userId
+  );
+  const { reservationInfo, paymentInfo } = payQueue[roomId][idxToDelete];
+
+  payQueue[roomId].splice(idxToDelete, 1);
+
+  return {
+    headers: {
+      method: "REDIRECT",
+      curQuery: "removeInQueue",
+      nextQuery: "apigateway",
+      endQuery: "apigateway",
+      params: {}
+    },
+    body: { reservationInfo, paymentInfo, status: 200 }
   };
 };

--- a/server/services/payment/query/queries.js
+++ b/server/services/payment/query/queries.js
@@ -11,8 +11,7 @@ function getElementsHaveSameRoomId(roomId) {
   return payQueue[roomId];
 }
 
-exports.inspectQueue = async ({ userInfo, paymentInfo, reservationInfo }) => {
-  const { userId, kakaoAccessToken } = userInfo;
+exports.inspectQueue = async ({ userId, paymentInfo, reservationInfo }) => {
   const { roomId, day, startTime, endTime } = reservationInfo;
   const sameRoomIdInPayQueue = getElementsHaveSameRoomId(roomId);
   let nextUrl = "";
@@ -21,13 +20,12 @@ exports.inspectQueue = async ({ userInfo, paymentInfo, reservationInfo }) => {
     sameRoomIdInPayQueue.length === 0 ||
     avoidReservationCollision({ day, startTime, endTime }, sameRoomIdInPayQueue)
   ) {
-    nextUrl = await getNextUrl({ kakaoAccessToken, paymentInfo });
+    nextUrl = await getNextUrl(roomId, userId, paymentInfo);
 
     if (nextUrl) {
       payQueue[roomId].push({
-        day,
-        startTime,
-        endTime,
+        reservationInfo,
+        paymentInfo,
         userId
       });
     }

--- a/server/services/payment/test/avoidReservationCollision.test.js
+++ b/server/services/payment/test/avoidReservationCollision.test.js
@@ -7,21 +7,27 @@ const myReservation = {
 };
 
 const case1 = {
-  day: [1, 2, 3],
-  startTime: [10, 10, 10],
-  endTime: [12, 12, 12]
+  reservationInfo: {
+    day: [1, 2, 3],
+    startTime: [10, 10, 10],
+    endTime: [12, 12, 12]
+  }
 };
 
 const case2 = {
-  day: [0, 1, 2],
-  startTime: [12, 14, 18],
-  endTime: [14, 16, 20]
+  reservationInfo: {
+    day: [0, 1, 2],
+    startTime: [12, 14, 18],
+    endTime: [14, 16, 20]
+  }
 };
 
 const case3 = {
-  day: [0, 4, 5],
-  startTime: [13, 17, 21],
-  endTime: [14, 18, 22]
+  reservationInfo: {
+    day: [0, 4, 5],
+    startTime: [13, 17, 21],
+    endTime: [14, 18, 22]
+  }
 };
 
 test("날짜가 하나도 겹치지 않을 때 True", () => {

--- a/server/services/payment/test/getQueueByUserId.test.js
+++ b/server/services/payment/test/getQueueByUserId.test.js
@@ -1,0 +1,64 @@
+const { getQueueByUserId } = require("../query/util");
+
+const payQueue = {
+  "1234": [
+    {
+      userId: "8493902",
+      reservationInfo: {
+        day: [1, 2, 3],
+        startTime: [1, 2, 3],
+        endTime: [2, 3, 4],
+        roomId: "1234"
+      }
+    },
+    {
+      userId: "9493738",
+      reservationInfo: {
+        day: [1, 2, 3],
+        startTime: [1, 2, 3],
+        endTime: [2, 3, 4],
+        roomId: "1234"
+      }
+    }
+  ],
+  "4431": [
+    {
+      userId: "8493902",
+      reservationInfo: {
+        day: [1, 2, 3],
+        startTime: [1, 2, 3],
+        endTime: [2, 3, 4],
+        roomId: "4431"
+      }
+    },
+    {
+      userId: "8493903",
+      reservationInfo: {
+        day: [1, 2, 3],
+        startTime: [1, 2, 3],
+        endTime: [2, 3, 4],
+        roomId: "4431"
+      }
+    }
+  ]
+};
+
+test("스터디룸 1234번에서 사용자 8493902의 결제 정보 반환", () => {
+  const queue = getQueueByUserId(payQueue["1234"], "8493902")[0];
+  expect(queue.reservationInfo).toEqual({
+    day: [1, 2, 3],
+    startTime: [1, 2, 3],
+    endTime: [2, 3, 4],
+    roomId: "1234"
+  });
+});
+
+test("스터디룸 4431번의 사용자 8493903의 결제 정보 반환", () => {
+  const queue = getQueueByUserId(payQueue["4431"], "8493903")[0];
+  expect(queue.reservationInfo).toEqual({
+    day: [1, 2, 3],
+    startTime: [1, 2, 3],
+    endTime: [2, 3, 4],
+    roomId: "4431"
+  });
+});


### PR DESCRIPTION
<!-- reviewer와 Assignees를 설정했는지 확인해주세요 -->
<!-- 제발!!!! 구현 내용을 자세하게 적어주세요😣 -->
<!-- ✨✨✨테스트 코드를 작성하였는지 확인해주세요✨✨✨ -->
<!-- 🚀 서비스 브랜치 -> develop 브랜치 로 최신 동기화 작업을 위한 PR이라면 "MergeToDevelop" 라벨을 달아주세요-->
<!-- 🚀 develop 브랜치 -> 서비스 브랜치 로 최신 동기화 작업을 위한 PR이라면 "서비스업데이트" 라벨을 달아주세요-->

# 구현 내용
## 수정
### inspectQueue
- 카카오 access token을 사용하는 것에 대한 필요성을 느끼지 못했다.
- params로 받는 인자중 userInfo 객체 대신 userId만 받기로 한다.

## 구현
### approvePayment
- 결제 준비 후 사용자가 결제 시도를 하면 실행되는 쿼리문.
- 결제 준비 때 받았던 결제 인증 토큰 `pg_token`으로 결제 승인을 받는다.
- 승인이 된다면 결제 정보를 결제 데이터베이스에 저장을 하고 예약 서비스에게 `addReservation` 쿼리를 요청한다.
- 승인이 거절된다면 큐에 있는 결제 정보를 삭제하고 게이트웨이에게 패킷을 보낸다.

### removeInQueue
- 예약 서비스의 `addReservation` 쿼리에 대한 응답으로 실행되는 쿼리이다.
- 큐에 있는 결제 정보를 삭제하고 게이트웨이에게 패킷을 보낸다.