### PR TITLE
fix(main_carousel): 새로고침시, 사용자가 소속된 그룹 캐로셀이 안 나타나는 점 수정

### DIFF
--- a/client/src/components/users/UserInfo/LoginButton.jsx
+++ b/client/src/components/users/UserInfo/LoginButton.jsx
@@ -97,8 +97,6 @@ const LoginButton = () => {
       };
       const patchResult = await fetch(url, options);
       if (patchResult.ok) {
-        userIndexDispatch(set_my_group(getResult.ownGroups));
-        userIndexDispatch(set_join_group(getResult.joiningGroups));
         setUserInfo({
           ...getResult,
           ...{ kakaoAccessToken: response.access_token }

--- a/client/src/components/users/myStudyCardCarousel/index.jsx
+++ b/client/src/components/users/myStudyCardCarousel/index.jsx
@@ -32,13 +32,15 @@ width: ${props => props.carouselWidth};
 `;
 
 const MyStudyCarousel = () => {
-  const { userIndexState } = useContext(UserContext);
-  const { myGroups, joinedGroups } = userIndexState;
-  const carouselWidth = myGroups.length ? myGroups.length * 10 + "em" : "100%";
-  const userGroups = myGroups.concat(joinedGroups);
+  const { userInfo } = useContext(UserContext);
+  const { ownGroups, joiningGroups } = userInfo;
+  const carouselWidth = ownGroups.length
+    ? ownGroups.length * 10 + "em"
+    : "100%";
+  const userGroups = ownGroups.concat(joiningGroups);
 
   useEffect(() => {
-    if (myGroups.length > 3)
+    if (ownGroups.length > 3)
       bulmaCarousel.attach(".carousel", {
         slidesToScroll: 1,
         slidesToShow: 3,

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -96,8 +96,8 @@ const MainPage = ({ history }) => {
     pageNationState,
     setPageNationState
   } = useContext(UserContext);
-  const { myGroups, joinedGroups, searchList } = userIndexState;
-  const { userId, userLocation } = userInfo;
+  const { searchList } = userIndexState;
+  const { userId, userLocation, ownGroups, joiningGroups } = userInfo;
 
   const lat = useRef();
   const lon = useRef();
@@ -141,7 +141,6 @@ const MainPage = ({ history }) => {
   }, [userLocation]);
 
   useEffect(() => {
-    console.log("data", data);
     if (!isHaveCardDataWhenLoaded(loading, data)) return;
     userIndexDispatch(set_groups(data));
   }, [data]);
@@ -151,7 +150,7 @@ const MainPage = ({ history }) => {
       <div className="main-jumbotron">
         {userId ? (
           <>
-            {myGroups.length || joinedGroups.length ? (
+            {ownGroups.length || joiningGroups.length ? (
               <MyStudyCarousel></MyStudyCarousel>
             ) : (
               <div className="no-groups">

--- a/client/src/reducer/users/index.jsx
+++ b/client/src/reducer/users/index.jsx
@@ -5,54 +5,22 @@ const SET_JOIN_GROUPS = "userIndex/SET_JOIN_GROUPS";
 
 export const set_groups = searchList => ({
   type: SET_GROUPS,
-  searchList,
+  searchList
 });
 
 export const set_additional_groups = searchList => ({
   type: SET_ADDTIONAL_GROUPS,
-  searchList,
+  searchList
 });
 
 export const set_my_group = myGroups => ({ type: SET_MY_GROUPS, myGroups });
 
 export const set_join_group = joinedGroups => ({
   type: SET_JOIN_GROUPS,
-  joinedGroups,
+  joinedGroups
 });
 
 export const initalState = {
-  joinedGroups: [
-    // {
-    //   id: 0,
-    //   days: [],
-    //   startTime: 0,
-    //   during: 0,
-    //   //location: { lat: 0, lon: 0 },
-    //   max_personnel: 0,
-    //   now_personnel: 0,
-    //   // min_personnel: 0,
-    //   title: "",
-    //   subtitle: "",
-    //   thumbnail: "",
-    //   tags: []
-    // }
-  ],
-  myGroups: [
-    // {
-    //   id: 0,
-    //   days: [],
-    //   startTime: 0,
-    //   during: 0,
-    //   //location: { lat: 0, lon: 0 },
-    //   max_personnel: 0,
-    //   now_personnel: 0,
-    //   // min_personnel: 0,
-    //   title: "",
-    //   subtitle: "",
-    //   thumbnail: "",
-    //   tags: []
-    // }
-  ],
   searchList: [
     // {
     //   id: 0,
@@ -85,13 +53,13 @@ export const initalState = {
       "Python",
       "Swift",
       "Ruby",
-      "기타",
+      "기타"
     ],
     자격증: ["강사", "병원", "아동", "IT", "인문", "산업", "기타"],
     외국어: ["영어", "중국어", "일본어", "불어", "스페인어", "기타"],
     취업: ["자소서", "면접", "인적성", "자격증", "기타"],
-    기타: ["기타"],
-  },
+    기타: ["기타"]
+  }
 };
 
 export const userIndexReducer = (state, action) => {
@@ -100,22 +68,22 @@ export const userIndexReducer = (state, action) => {
     case SET_GROUPS:
       return {
         ...state,
-        searchList,
+        searchList
       };
     case SET_ADDTIONAL_GROUPS:
       return {
         ...state,
-        searchList: [...state.searchList, ...searchList],
+        searchList: [...state.searchList, ...searchList]
       };
     case SET_MY_GROUPS:
       return {
         ...state,
-        myGroups: [...state.myGroups, ...myGroups],
+        myGroups: [...state.myGroups, ...myGroups]
       };
     case SET_JOIN_GROUPS:
       return {
         ...state,
-        joinedGroups: [...state.joinedGroups, ...joinedGroups],
+        joinedGroups: [...state.joinedGroups, ...joinedGroups]
       };
     default:
       return state;


### PR DESCRIPTION
<!-- reviewer와 Assignees를 설정했는지 확인해주세요 -->
<!-- 제발!!!! 구현 내용을 자세하게 적어주세요😣 -->
<!-- ✨✨✨테스트 코드를 작성하였는지 확인해주세요✨✨✨ -->
<!-- 🚀 서비스 브랜치 -> develop 브랜치 로 최신 동기화 작업을 위한 PR이라면 "MergeToDevelop" 라벨을 달아주세요-->
<!-- 🚀 develop 브랜치 -> 서비스 브랜치 로 최신 동기화 작업을 위한 PR이라면 "서비스업데이트" 라벨을 달아주세요-->

# 구현 내용
- 캐로셀이 그리는 데이터를 userIndexState로 사용해서 생긴 문제
- userIndexState의 myGroups, joinedGroups는 로그인 버튼을 눌렀을 때만 가져오는 상태이기 때문
- 그래서 같이 가져오는 userInfo의 ownGroups, joiningGroups를 사용
- userIndexState의 두 속성은 중복됨과 동시에 불필요해 제거

