### PR TITLE
잔버그 수정 및 그룹 검색 시, 위치 정보 표시

### DIFF
--- a/client/src/lib/coord2string.jsx
+++ b/client/src/lib/coord2string.jsx
@@ -2,7 +2,7 @@ import { useState, useLayoutEffect, useEffect } from "react";
 
 function useCoord2String(kakao, lat, lon) {
   const geocoder = new kakao.maps.services.Geocoder();
-  const [locationString, setString] = useState(`위도: ${lat} 경도: ${lon}`);
+  const [locationString, setString] = useState("");
 
   useEffect(() => {
     const coords = new kakao.maps.LatLng(lat, lon);

--- a/client/src/lib/useInfiniteScroll.jsx
+++ b/client/src/lib/useInfiniteScroll.jsx
@@ -15,11 +15,12 @@ const useInfiniteScroll = callback => {
 
   function handleScroll() {
     if (
-      window.innerHeight + document.documentElement.scrollTop + 120 <
+      window.innerHeight + document.documentElement.scrollTop + 400 <
         document.documentElement.offsetHeight ||
       isFetching
     )
       return;
+
     setIsFetching(true);
   }
 

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -52,11 +52,15 @@ const Main = styled.div`
   }
 
   .location-info-block {
-    font-family: 'Black Han Sans', sans-serif;
-    font-size: 3rem;
-    margin-left: 9.5rem;
-    margin-bottom: 2rem;
+    display: flex;
+    justify-content: center;
+    font-weight: bold;
+    align-self: center;
+    margin: 0 0 1em 0;
+    padding: 0.1em 1em;
+    border-radius: 5px;
 
+    font-size: 0.8rem;
   }
 
   .study-group-list{
@@ -179,7 +183,7 @@ const MainPage = ({ history }) => {
         {curLocation && (
           <span>
             {" "}
-            <strong className="has-text-info"> {curLocation} </strong> 근처
+            🚩<strong className="has-text-info"> {curLocation} </strong> 근처
           </span>
         )}
       </div>

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -51,6 +51,14 @@ const Main = styled.div`
     }
   }
 
+  .location-info-block {
+    font-family: 'Black Han Sans', sans-serif;
+    font-size: 3rem;
+    margin-left: 9.5rem;
+    margin-bottom: 2rem;
+
+  }
+
   .study-group-list{
       align-self:center;
       min-height: 200px;
@@ -168,7 +176,12 @@ const MainPage = ({ history }) => {
       </div>
 
       <div className="location-info-block">
-        <span> {curLocation} 주변에 있는 스터디입니다. </span>
+        {curLocation && (
+          <span>
+            {" "}
+            <strong className="has-text-info"> {curLocation} </strong> 근처
+          </span>
+        )}
       </div>
 
       <div className="study-group-list">

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -133,7 +133,7 @@ const MainPage = ({ history }) => {
       };
 
       if (isLastPagenation(additionalGroups))
-        changedPageNationState.isLastItems = true;
+        changedPageNationState.isLastItem = true;
 
       userIndexDispatch(set_additional_groups(additionalGroups));
       setPageNationState(changedPageNationState);

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -126,8 +126,8 @@ const MainPage = ({ history }) => {
 
       userIndexDispatch(set_additional_groups(additionalGroups));
       setPageNationState(changedPageNationState);
+      setIsFetching(false);
     });
-    setIsFetching(false);
   }
 
   useEffect(() => {

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useEffect, useContext, useRef } from "react";
+import React, { useEffect, useContext } from "react";
 
 import useInfiniteScroll from "../../lib/useInfiniteScroll";
 import styled from "styled-components";
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 import StudyGroupCard from "../../components/users/groupCard";
 import MyStudyCarousel from "../../components/users/myStudyCardCarousel";
 
+import useCoord2String from "../../lib/coord2string";
 import { set_groups } from "../../reducer/users";
 import { UserContext } from "./index";
 import { REQUEST_URL } from "../../config.json";
@@ -97,21 +98,19 @@ const MainPage = ({ history }) => {
   const { searchList } = userIndexState;
   const { userId, userLocation, ownGroups, joiningGroups } = userInfo;
 
-  const lat = useRef();
-  const lon = useRef();
-  lat.current = userLocation.lat;
-  lon.current = userLocation.lon;
+  const { lat, lon } = userLocation;
 
   let { loading, data, error, request } = getApiAxiosState;
 
   const [isFetching, setIsFetching] = useInfiniteScroll(loadAdditionalItems);
+  const [curLocation] = useCoord2String(window.kakao, lat, lon);
 
   function loadAdditionalItems() {
     const { page_idx, category, isLastItem } = pageNationState;
     if (isLastItem) return;
-    let url = `${REQUEST_URL}/api/search/all/location/${lat.current}/${lon.current}/page/${page_idx}/true`;
+    let url = `${REQUEST_URL}/api/search/all/location/${lat}/${lon}/page/${page_idx}/true`;
     if (category)
-      url = `${REQUEST_URL}/api/search/all/category/${category}/location/${lat.current}/${lon.current}/page/${page_idx}/true`;
+      url = `${REQUEST_URL}/api/search/all/category/${category}/location/${lat}/${lon}/page/${page_idx}/true`;
 
     axios.get(url).then(({ data }) => {
       const additionalGroups = data;
@@ -131,11 +130,8 @@ const MainPage = ({ history }) => {
   }
 
   useEffect(() => {
-    isSetPositionDuringLoading(loading, lat.current, lon.current) &&
-      request(
-        "get",
-        `/search/all/location/${lat.current}/${lon.current}/page/0/true`
-      );
+    isSetPositionDuringLoading(loading, lat, lon) &&
+      request("get", `/search/all/location/${lat}/${lon}/page/0/true`);
   }, [userLocation]);
 
   useEffect(() => {
@@ -169,6 +165,10 @@ const MainPage = ({ history }) => {
             </div>
           </div>
         )}
+      </div>
+
+      <div className="location-info-block">
+        <span> {curLocation} 주변에 있는 스터디입니다. </span>
       </div>
 
       <div className="study-group-list">

--- a/client/src/pages/users/search.jsx
+++ b/client/src/pages/users/search.jsx
@@ -4,9 +4,9 @@ import styled from "styled-components";
 
 import StudyGroupCard from "../../components/users/groupCard";
 import useInfiniteScroll from "../../lib/useInfiniteScroll";
+import useCoord2String from "../../lib/coord2string";
 
 import { REQUEST_URL } from "../../config.json";
-import { set_groups } from "../../reducer/users";
 import { UserContext } from "./index";
 import axios from "axios";
 
@@ -31,6 +31,13 @@ const StyledSearch = styled.div`
         }
       }
     }
+  }
+
+  .location-info-block {
+    font-family: 'Black Han Sans', sans-serif;
+    font-size: 3rem;
+    margin-left: 9.5rem;
+    margin-bottom: 2rem;
   }
 
   .study-group-list{
@@ -86,6 +93,7 @@ const Search = ({ location, match, history }) => {
     searchData: []
   });
 
+  const [curLocation] = useCoord2String(window.kakao, lat, lon);
   const [isFetching, setIsFetching] = useInfiniteScroll(loadAdditionalItems);
 
   const [pageState, setpageState] = useState({
@@ -143,7 +151,6 @@ const Search = ({ location, match, history }) => {
           searchData: newData
         };
         setSearchState(newSearchData);
-        //userIndexDispatch(set_additional_groups(additionalGroups));
         setpageState(changedPageNationState);
       });
 
@@ -185,6 +192,15 @@ const Search = ({ location, match, history }) => {
 
   return (
     <StyledSearch>
+      <div className="location-info-block">
+        {curLocation && (
+          <span>
+            {" "}
+            <strong className="has-text-info"> {curLocation} </strong> 근처
+          </span>
+        )}
+      </div>
+
       <div className="study-group-list">
         {(() => {
           if (searchState.isLoading) return <h3> 로딩 중... </h3>;

--- a/client/src/pages/users/search.jsx
+++ b/client/src/pages/users/search.jsx
@@ -84,13 +84,7 @@ const Search = ({ location, match, history }) => {
 
   const pathname = location.pathname;
 
-  const {
-    userIndexState,
-    userIndexDispatch,
-    userInfo,
-    getApiAxiosState
-  } = useContext(UserContext);
-  const { searchList } = userIndexState;
+  const { userInfo } = useContext(UserContext);
   const { userLocation } = userInfo;
 
   let { lat, lon } = userLocation;

--- a/client/src/pages/users/search.jsx
+++ b/client/src/pages/users/search.jsx
@@ -94,7 +94,6 @@ const Search = ({ location, match, history }) => {
   const { userLocation } = userInfo;
 
   let { lat, lon } = userLocation;
-  let { loading, data, error, request } = getApiAxiosState;
 
   const [searchState, setSearchState] = useState({
     isLoading: true,
@@ -181,6 +180,7 @@ const Search = ({ location, match, history }) => {
     }
 
     if (pathname === "/search/tags") {
+      if (!lat || !lon) return;
       const data = {
         tags: [query],
         lat,
@@ -196,7 +196,7 @@ const Search = ({ location, match, history }) => {
         setSearchState(initData);
       });
     }
-  }, [query]);
+  }, [query, userLocation]);
 
   return (
     <StyledSearch>

--- a/client/src/pages/users/search.jsx
+++ b/client/src/pages/users/search.jsx
@@ -123,7 +123,7 @@ const Search = ({ location, match, history }) => {
         };
 
         if (isLastPagenation(additionalGroups))
-          changedPageNationState.isLastItems = true;
+          changedPageNationState.isLastItem = true;
 
         const newData = [...searchState.searchData, ...additionalGroups];
         const newSearchData = {
@@ -151,7 +151,7 @@ const Search = ({ location, match, history }) => {
         };
 
         if (isLastPagenation(additionalGroups))
-          changedPageNationState.isLastItems = true;
+          changedPageNationState.isLastItem = true;
 
         const newData = [...searchState.searchData, ...additionalGroups];
         const newSearchData = {

--- a/client/src/pages/users/search.jsx
+++ b/client/src/pages/users/search.jsx
@@ -146,9 +146,9 @@ const Search = ({ location, match, history }) => {
         //userIndexDispatch(set_additional_groups(additionalGroups));
         setpageState(changedPageNationState);
       });
-    }
 
-    setIsFetching(false);
+      setIsFetching(false);
+    }
   }
 
   useEffect(() => {

--- a/client/src/pages/users/search.jsx
+++ b/client/src/pages/users/search.jsx
@@ -13,49 +13,57 @@ import axios from "axios";
 const StyledSearch = styled.div`
   display: flex;
   flex-direction: column;
-  padding-left: 5%;
-  padding-right: 5%;
 
-  .main-page-title{
-    font-family: 'Black Han Sans', sans-serif;
+  .main-jumbotron {
+    display: flex;
+    justify-content: center;
+
+    margin: 0 auto;
+    font-family: "Black Han Sans", sans-serif;
     color: #000000;
+    padding-left: 5%;
     padding: 5%;
-    align-self:start;
+    align-self: start;
+    display: flex;
+
     .main-title {
-        font-size: 6em;
-      }
-    .main-subtitle{
-        font-size: 4em;
-        .highlight{
-            color:#e41d60
-        }
+      font-size: 3.7em;
+      border-bottom: 0.2px solid black;
+
+      &.highlight {
+        color: #e41d60;
       }
     }
   }
 
   .location-info-block {
-    font-family: 'Black Han Sans', sans-serif;
-    font-size: 3rem;
-    margin-left: 9.5rem;
-    margin-bottom: 2rem;
+    display: flex;
+    justify-content: center;
+    font-weight: bold;
+    align-self: center;
+    margin: 0 0 1em 0;
+    padding: 0.1em 1em;
+    border-radius: 5px;
+
+    font-size: 0.8rem;
   }
 
-  .study-group-list{
-      align-self:center;
-      min-height: 200px;
+  .study-group-list {
+    align-self: center;
+    min-height: 200px;
 
-      display: flex;
-      flex-direction: row;
-      justify-content: space-evenly;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
 
-      background-color: #f8f0ee;
-      width: 68rem;
-      flex-wrap: wrap;
-      padding: 0 1rem;
-      margin:0 10%;
-      .study-group-card{
-          margin: 2em;
-      }
+    background-color: #f8f0ee;
+    width: 68rem;
+    flex-wrap: wrap;
+    padding: 0 1rem;
+    margin: 0 10%;
+    .study-group-card {
+      margin: 2em;
+    }
   }
 `;
 
@@ -192,11 +200,17 @@ const Search = ({ location, match, history }) => {
 
   return (
     <StyledSearch>
+      <div className="main-jumbotron">
+        <div className="main-title highlight">
+          🔍 {pathname === "/search" ? query : `#${query}`}
+        </div>
+      </div>
+
       <div className="location-info-block">
         {curLocation && (
           <span>
             {" "}
-            <strong className="has-text-info"> {curLocation} </strong> 근처
+            🚩<strong className="has-text-info"> {curLocation} </strong> 근처
           </span>
         )}
       </div>


### PR DESCRIPTION
<!-- reviewer와 Assignees를 설정했는지 확인해주세요 -->
<!-- 제발!!!! 구현 내용을 자세하게 적어주세요😣 -->
<!-- ✨✨✨테스트 코드를 작성하였는지 확인해주세요✨✨✨ -->
<!-- 🚀 서비스 브랜치 -> develop 브랜치 로 최신 동기화 작업을 위한 PR이라면 "MergeToDevelop" 라벨을 달아주세요-->
<!-- 🚀 develop 브랜치 -> 서비스 브랜치 로 최신 동기화 작업을 위한 PR이라면 "서비스업데이트" 라벨을 달아주세요-->

# 구현 내용
- 무한 스크롤에서 같은 데이터를 두번 요청하는 현상 수정
  - setIsFetching(false)가 비동기 로직을 거치기전에 실행되서 발생한 현상
- 그룹 탐색시, 기준으로 정해진 장소명을 페이지에 표시
- 검색 페이지의 검색한 내용 표시
- 탐색 페이지에서 새로고침시, 데이터가 하나도 나오지 않는 현상 수정
  - 맨 처음에 userLocation 속성들이 null이 뜨기 때문에, 예외처리 적용하여 해결

