### PR TITLE
카테고리 검색 결과 라우팅 추가

### DIFF
--- a/client/src/components/users/groupDetail/Header.jsx
+++ b/client/src/components/users/groupDetail/Header.jsx
@@ -1,5 +1,8 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useContext } from "react";
 import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+import { UserContext } from "../../../pages/users";
 
 const StyledHeader = styled.div`
   .hero-body {
@@ -10,9 +13,28 @@ const StyledHeader = styled.div`
 
 const Header = ({ groupData }) => {
   const { title, category } = groupData;
+  const {
+    userInfo,
+    getApiAxiosState,
+    pageNationState,
+    setPageNationState
+  } = useContext(UserContext);
+  const { request } = getApiAxiosState;
+
   const categoryBtnEvent = useCallback(e => {
-    const categoryName = e.target.textContent.trim();
-    alert(categoryName);
+    const categoryName = e.target.textContent.trim().replace(/(\s*)/g, "");
+    const { lat, lon } = userInfo.userLocation;
+    const changedPageNationState = {
+      ...pageNationState,
+      page_idx: 1,
+      category: categoryName
+    };
+    setPageNationState(changedPageNationState);
+
+    request(
+      "get",
+      `/search/all/category/${categoryName}/location/${lat}/${lon}/page/0/true`
+    );
   }, []);
 
   return (
@@ -20,18 +42,20 @@ const Header = ({ groupData }) => {
       <div className="hero-body">
         <h2 className="title has-text-danger is-size-2">{title}</h2>
         <div className="buttons">
-          <button
+          <Link
+            to={`/category?query=${category[0]}`}
             className="button is-primary is-small"
             onClick={categoryBtnEvent}
           >
             {category[0]}
-          </button>
-          <button
+          </Link>
+          <Link
+            to={`/category?query=${category[1]}`}
             className="button is-primary is-small"
             onClick={categoryBtnEvent}
           >
             {category[1]}
-          </button>
+          </Link>
         </div>
       </div>
     </StyledHeader>

--- a/client/src/components/users/groupDetail/Main.jsx
+++ b/client/src/components/users/groupDetail/Main.jsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from "react";
 import styled from "styled-components";
-import classnames from "classnames";
 import Subtitle from "../groupCard/Subtitle";
 import Location from "../common/Location";
 import Time from "../groupCard/Time";

--- a/client/src/components/users/studySearchNavbar/StudyNavbarItem.jsx
+++ b/client/src/components/users/studySearchNavbar/StudyNavbarItem.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useRef } from "react";
+import React, { useCallback, useContext } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
@@ -51,7 +51,7 @@ const StudyNavbarItem = ({ primaryCategory, secondaryCategories }) => {
   );
 
   const itemList = secondaryCategories.map((category, idx) => (
-    <Link to="/">
+    <Link to={`/category?query=${category}`}>
       <span key={idx} className="navbar-item" onClick={searchGroups}>
         {category}
       </span>

--- a/client/src/pages/users/Main.jsx
+++ b/client/src/pages/users/Main.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useContext } from "react";
-
 import useInfiniteScroll from "../../lib/useInfiniteScroll";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
@@ -98,7 +97,7 @@ const Main = styled.div`
 
 const takeCardAmount = 12;
 
-const MainPage = ({ history }) => {
+const MainPage = ({ history, location }) => {
   const {
     userIndexState,
     userIndexDispatch,
@@ -142,6 +141,7 @@ const MainPage = ({ history }) => {
   }
 
   useEffect(() => {
+    if (location.pathname !== "/") return;
     isSetPositionDuringLoading(loading, lat, lon) &&
       request("get", `/search/all/location/${lat}/${lon}/page/0/true`);
   }, [userLocation]);

--- a/client/src/pages/users/groupDetail.jsx
+++ b/client/src/pages/users/groupDetail.jsx
@@ -76,7 +76,7 @@ const GroupDetail = ({ match, history }) => {
           const isMyGroup = groupData.leader === userInfo.userId;
           return (
             <>
-              <Header groupData={groupData}></Header>
+              <Header groupData={groupData} history={history}></Header>
               <Main
                 groupData={groupData}
                 dispatch={dispatch}

--- a/client/src/pages/users/index.jsx
+++ b/client/src/pages/users/index.jsx
@@ -111,7 +111,7 @@ const UserPage = () => {
           <Route path="/" component={Header} />
         </Switch>
         <Switch>
-          <Route exact path="/" component={MainPage} />
+          <Route exact path={["/", "/category"]} component={MainPage} />
           <Route exact path="/group/create" component={GroupCreatePage} />
           <Route exact path="/group/update/:id" component={GroupUpdatePage} />
           <Route path="/group/detail/:id" component={GroupDetailPage} />

--- a/client/src/reducer/users/groupCreate.jsx
+++ b/client/src/reducer/users/groupCreate.jsx
@@ -98,7 +98,7 @@ export const initialState = {
     title: "",
     subtitle: "",
     intro: "",
-    locatoin: { lat: null, lon: null },
+    location: { lat: null, lon: null },
     days: [],
     startTime: 1,
     during: 1,
@@ -179,7 +179,6 @@ export const groupCreateReducer = (state, action) => {
       const { lat, lon } = action;
       const location = { lat, lon };
       data = { ...data, location };
-      console.log(data);
       return { ...state, data };
 
     default:


### PR DESCRIPTION
<!-- reviewer와 Assignees를 설정했는지 확인해주세요 -->
<!-- 제발!!!! 구현 내용을 자세하게 적어주세요😣 -->
<!-- ✨✨✨테스트 코드를 작성하였는지 확인해주세요✨✨✨ -->
<!-- 🚀 서비스 브랜치 -> develop 브랜치 로 최신 동기화 작업을 위한 PR이라면 "MergeToDevelop" 라벨을 달아주세요-->
<!-- 🚀 develop 브랜치 -> 서비스 브랜치 로 최신 동기화 작업을 위한 PR이라면 "서비스업데이트" 라벨을 달아주세요-->

# 구현 내용
- 기존 카테고리 검색 결과는 인덱스에서 진행 되었음
- 그래서 다른 path에서 카테고리 버튼을 클릭 시, 해당 카테고리의 데이터 요청과 동시에 인덱스 page로 가 한번 더 전체 데이터를 요청했었음
- 그래서 메인 페이지(인덱스)와 카테고리 검색 결과를 별도로 두어, 로직을 분리해 한번만 데이터를 요청하게 함

